### PR TITLE
Fix error when accessing a single attribute before any have been added.

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -35,7 +35,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * @var array
      */
-    private $attributes;
+    private $attributes = [];
 
     /**
      * @var array

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -76,6 +76,10 @@ class ServerRequestTest extends TestCase
         $this->assertEmpty($this->request->getAttributes());
     }
 
+    public function testSingleAttributesWhenEmptyByDefault()
+    {
+        $this->assertEmpty($this->request->getAttribute('does-not-exist'));
+    }
     /**
      * @depends testAttributesAreEmptyByDefault
      */


### PR DESCRIPTION
When using `getAttribute` before `withAttribute` has been called the following error happens:

`array_key_exists() expects parameter 2 to be array, null given`

This fix makes sure the array is initialized in the `ServerRequest` class. I'm open to other suggestions for solving this issue.

cc: @weierophinney 