### PR TITLE
[WIP] Feature: "relative" stream

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -114,9 +114,8 @@ abstract class AbstractSerializer
             $headers[$currentHeader][] = $value . ltrim($line);
         }
 
-        $body = new RelativeStream($stream, $stream->tell());
-
-        return [$headers, $body];
+        // use RelativeStream to avoid copying initial stream into memory
+        return [$headers, new RelativeStream($stream, $stream->tell())];
     }
 
     /**

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -114,13 +114,7 @@ abstract class AbstractSerializer
             $headers[$currentHeader][] = $value . ltrim($line);
         }
 
-        $body = new Stream('php://temp', 'wb+');
-        if (! $stream->eof()) {
-            while ($data = $stream->read(4096)) {
-                $body->write($data);
-            }
-            $body->rewind();
-        }
+        $body = new RelativeStream($stream, $stream->tell());
 
         return [$headers, $body];
     }

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use Psr\Http\Message\StreamInterface;
+
+class RelativeStream implements StreamInterface
+{
+    /**
+     * @var StreamInterface
+     */
+    private $decodatedStream;
+
+    /**
+     * @var int
+     */
+    private $offset;
+
+    /**
+     * Class constructor
+     *
+     * @param StreamInterface $decodatedStream
+     * @param $offset
+     */
+    public function __construct(StreamInterface $decodatedStream, $offset)
+    {
+        $this->decodatedStream = $decodatedStream;
+        $this->offset = $offset;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __toString()
+    {
+        $this->seek(0);
+        return $this->getContents();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function close()
+    {
+        $this->decodatedStream->close();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function detach()
+    {
+        return $this->decodatedStream->detach();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSize()
+    {
+        return $this->decodatedStream->getSize() - $this->offset;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function tell()
+    {
+        return $this->decodatedStream->tell() - $this->offset;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function eof()
+    {
+        return $this->decodatedStream->eof();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSeekable()
+    {
+        return $this->decodatedStream->isSeekable();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        switch ($whence) {
+            case SEEK_SET:
+                $basePos = $this->offset;
+                break;
+            default:
+                $basePos = 0;
+        }
+        return $this->decodatedStream->seek($offset + $basePos, $whence);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function rewind()
+    {
+        return $this->seek(0);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isWritable()
+    {
+        return $this->decodatedStream->isWritable();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function write($string)
+    {
+        return $this->decodatedStream->write($string);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isReadable()
+    {
+        return $this->decodatedStream->isReadable();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function read($length)
+    {
+        return $this->decodatedStream->read($length);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getContents()
+    {
+        return $this->decodatedStream->getContents();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMetadata($key = null)
+    {
+        return $this->decodatedStream->getMetadata($key);
+    }
+}

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -36,7 +36,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function __toString()
     {
@@ -45,7 +45,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function close()
     {
@@ -53,7 +53,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function detach()
     {
@@ -61,7 +61,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getSize()
     {
@@ -69,7 +69,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function tell()
     {
@@ -77,7 +77,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function eof()
     {
@@ -85,7 +85,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function isSeekable()
     {
@@ -93,7 +93,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function seek($offset, $whence = SEEK_SET)
     {
@@ -108,7 +108,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function rewind()
     {
@@ -116,7 +116,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function isWritable()
     {
@@ -124,7 +124,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function write($string)
     {
@@ -132,7 +132,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function isReadable()
     {
@@ -140,7 +140,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function read($length)
     {
@@ -148,7 +148,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getContents()
     {
@@ -156,7 +156,7 @@ class RelativeStream implements StreamInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getMetadata($key = null)
     {

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -11,6 +11,13 @@ namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
 
+/**
+ * Class RelativeStream
+ *
+ * Wrapper for default Stream class, representing subpart (starting from given offset) of initial stream.
+ * It can be used to avoid copying full stream, conserving memory.
+ * @example see Zend\Diactoros\AbstractSerializer::splitStream()
+ */
 class RelativeStream implements StreamInterface
 {
     /**
@@ -26,13 +33,13 @@ class RelativeStream implements StreamInterface
     /**
      * Class constructor
      *
-     * @param StreamInterface $decodatedStream
+     * @param StreamInterface $decoratedStream
      * @param int $offset
      */
-    public function __construct(StreamInterface $decodatedStream, $offset)
+    public function __construct(StreamInterface $decoratedStream, $offset)
     {
-        $this->decoratedStream = $decodatedStream;
-        $this->offset = $offset;
+        $this->decoratedStream = $decoratedStream;
+        $this->offset = (int)$offset;
     }
 
     /**
@@ -97,14 +104,10 @@ class RelativeStream implements StreamInterface
      */
     public function seek($offset, $whence = SEEK_SET)
     {
-        switch ($whence) {
-            case SEEK_SET:
-                $basePos = $this->offset;
-                break;
-            default:
-                $basePos = 0;
+        if ($whence == SEEK_SET) {
+            return $this->decoratedStream->seek($offset + $this->offset, $whence);
         }
-        return $this->decoratedStream->seek($offset + $basePos, $whence);
+        return $this->decoratedStream->seek($offset, $whence);
     }
 
     /**

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -16,7 +16,7 @@ class RelativeStream implements StreamInterface
     /**
      * @var StreamInterface
      */
-    private $decodatedStream;
+    private $decoratedStream;
 
     /**
      * @var int
@@ -31,7 +31,7 @@ class RelativeStream implements StreamInterface
      */
     public function __construct(StreamInterface $decodatedStream, $offset)
     {
-        $this->decodatedStream = $decodatedStream;
+        $this->decoratedStream = $decodatedStream;
         $this->offset = $offset;
     }
 
@@ -49,7 +49,7 @@ class RelativeStream implements StreamInterface
      */
     public function close()
     {
-        $this->decodatedStream->close();
+        $this->decoratedStream->close();
     }
 
     /**
@@ -57,7 +57,7 @@ class RelativeStream implements StreamInterface
      */
     public function detach()
     {
-        return $this->decodatedStream->detach();
+        return $this->decoratedStream->detach();
     }
 
     /**
@@ -65,7 +65,7 @@ class RelativeStream implements StreamInterface
      */
     public function getSize()
     {
-        return $this->decodatedStream->getSize() - $this->offset;
+        return $this->decoratedStream->getSize() - $this->offset;
     }
 
     /**
@@ -73,7 +73,7 @@ class RelativeStream implements StreamInterface
      */
     public function tell()
     {
-        return $this->decodatedStream->tell() - $this->offset;
+        return $this->decoratedStream->tell() - $this->offset;
     }
 
     /**
@@ -81,7 +81,7 @@ class RelativeStream implements StreamInterface
      */
     public function eof()
     {
-        return $this->decodatedStream->eof();
+        return $this->decoratedStream->eof();
     }
 
     /**
@@ -89,7 +89,7 @@ class RelativeStream implements StreamInterface
      */
     public function isSeekable()
     {
-        return $this->decodatedStream->isSeekable();
+        return $this->decoratedStream->isSeekable();
     }
 
     /**
@@ -104,7 +104,7 @@ class RelativeStream implements StreamInterface
             default:
                 $basePos = 0;
         }
-        return $this->decodatedStream->seek($offset + $basePos, $whence);
+        return $this->decoratedStream->seek($offset + $basePos, $whence);
     }
 
     /**
@@ -120,7 +120,7 @@ class RelativeStream implements StreamInterface
      */
     public function isWritable()
     {
-        return $this->decodatedStream->isWritable();
+        return $this->decoratedStream->isWritable();
     }
 
     /**
@@ -128,7 +128,7 @@ class RelativeStream implements StreamInterface
      */
     public function write($string)
     {
-        return $this->decodatedStream->write($string);
+        return $this->decoratedStream->write($string);
     }
 
     /**
@@ -136,7 +136,7 @@ class RelativeStream implements StreamInterface
      */
     public function isReadable()
     {
-        return $this->decodatedStream->isReadable();
+        return $this->decoratedStream->isReadable();
     }
 
     /**
@@ -144,7 +144,7 @@ class RelativeStream implements StreamInterface
      */
     public function read($length)
     {
-        return $this->decodatedStream->read($length);
+        return $this->decoratedStream->read($length);
     }
 
     /**
@@ -152,7 +152,7 @@ class RelativeStream implements StreamInterface
      */
     public function getContents()
     {
-        return $this->decodatedStream->getContents();
+        return $this->decoratedStream->getContents();
     }
 
     /**
@@ -160,6 +160,6 @@ class RelativeStream implements StreamInterface
      */
     public function getMetadata($key = null)
     {
-        return $this->decodatedStream->getMetadata($key);
+        return $this->decoratedStream->getMetadata($key);
     }
 }

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -27,7 +27,7 @@ class RelativeStream implements StreamInterface
      * Class constructor
      *
      * @param StreamInterface $decodatedStream
-     * @param $offset
+     * @param int $offset
      */
     public function __construct(StreamInterface $decodatedStream, $offset)
     {

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -87,4 +87,58 @@ class RelativeStreamTest extends TestCase
         $ret = $stream->isReadable();
         $this->assertEquals(false, $ret);
     }
+
+    public function testSeek()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->seek(126, SEEK_SET)->shouldBeCalled()->willReturn(0);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->seek(26);
+        $this->assertEquals(0, $ret);
+    }
+
+    public function testRewind()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->seek(100, SEEK_SET)->shouldBeCalled()->willReturn(0);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->rewind();
+        $this->assertEquals(0, $ret);
+    }
+
+    public function testWrite()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->write("foobaz")->shouldBeCalled()->willReturn(6);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->write("foobaz");
+        $this->assertEquals(6, $ret);
+    }
+
+    public function testRead()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->read(3)->shouldBeCalled()->willReturn("foo");
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->read(3);
+        $this->assertEquals("foo", $ret);
+    }
+
+    public function testGetContents()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->getContents()->shouldBeCalled()->willReturn("foo");
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->getContents();
+        $this->assertEquals("foo", $ret);
+    }
+
+    public function testGetMetadata()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->getMetadata("bar")->shouldBeCalled()->willReturn("foo");
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->getMetadata("bar");
+        $this->assertEquals("foo", $ret);
+    }
 }

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -14,7 +14,7 @@ use Zend\Diactoros\RelativeStream;
 use Zend\Diactoros\Stream;
 
 /**
- * @covers RelativeStream
+ * @covers \Zend\Diactoros\RelativeStream
  */
 class RelativeStreamTest extends TestCase
 {

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\RelativeStream;
+use Zend\Diactoros\Stream;
+
+class RelativeStreamTest extends TestCase
+{
+    public function testToString()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->seek(100, SEEK_SET)->shouldBeCalled();
+        $decorated->getContents()->shouldBeCalled()->willReturn('foobarbaz');
+
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->__toString();
+        $this->assertEquals('foobarbaz', $ret);
+    }
+
+    public function testClose()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->close()->shouldBeCalled();
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $stream->close();
+    }
+
+    public function testDetach()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->detach()->shouldBeCalled()->willReturn(250);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->detach();
+        $this->assertEquals(250, $ret);
+    }
+
+    public function testGetSize()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->getSize()->shouldBeCalled()->willReturn(250);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->getSize();
+        $this->assertEquals(150, $ret);
+    }
+
+    public function testTell()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->tell()->shouldBeCalled()->willReturn(188);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->tell();
+        $this->assertEquals(88, $ret);
+    }
+
+    public function testIsSeekable()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->isSeekable()->shouldBeCalled()->willReturn(true);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->isSeekable();
+        $this->assertEquals(true, $ret);
+    }
+
+    public function testIsWritable()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->isWritable()->shouldBeCalled()->willReturn(true);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->isWritable();
+        $this->assertEquals(true, $ret);
+    }
+
+    public function testIsReadable()
+    {
+        $decorated = $this->prophesize(Stream::class);
+        $decorated->isReadable()->shouldBeCalled()->willReturn(false);
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $ret = $stream->isReadable();
+        $this->assertEquals(false, $ret);
+    }
+}

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -13,6 +13,9 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Diactoros\RelativeStream;
 use Zend\Diactoros\Stream;
 
+/**
+ * @covers RelativeStream
+ */
 class RelativeStreamTest extends TestCase
 {
     public function testToString()

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -318,7 +318,7 @@ class SerializerTest extends TestCase
         $stream->expects($this->exactly(strlen($headers)))
             ->method('read')
             ->with(1)
-            ->will($this->returnCallback(function() use ($payload) {
+            ->will($this->returnCallback(function () use ($payload) {
                 static $i = 0;
                 return $payload[$i++];
             }));

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Diactoros\Request;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\RelativeStream;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Request\Serializer;
 use Zend\Diactoros\Stream;
@@ -296,5 +297,33 @@ class SerializerTest extends TestCase
             ->will($this->returnValue(false));
 
         Serializer::fromStream($stream);
+    }
+
+    public function testFromStreamStopsReadingAfterScanningHeader()
+    {
+        $headers = "POST /foo HTTP/1.0\r\nContent-Type: text/plain\r\nX-Foo-Bar: Baz;\r\n Bat\r\n\r\n";
+        $payload = $headers . "Content!";
+
+        $stream = $this
+            ->getMockBuilder('Psr\Http\Message\StreamInterface')
+            ->getMock();
+
+        $stream->expects($this->once())->method('isReadable')
+            ->will($this->returnValue(true));
+
+        $stream->expects($this->once())->method('isSeekable')
+            ->will($this->returnValue(true));
+
+        // assert that full request body is not read, and returned as RelativeStream instead
+        $stream->expects($this->exactly(strlen($headers)))
+            ->method('read')
+            ->with(1)
+            ->will($this->returnCallback(function() use ($payload) {
+                static $i = 0;
+                return $payload[$i++];
+            }));
+
+        $stream = Serializer::fromStream($stream);
+        $this->assertInstanceOf(RelativeStream::class, $stream->getBody());
     }
 }


### PR DESCRIPTION
Initial implementation of "relative" stream, representing subpart of another stream, to be reviewed.

It is a first step towards parsing large bodies that may not fit in PHP's available memory. 

There are at least two concerns for now:

* using relative stream will change original stream's internal pointer. This could be avoided by adding calls to `tell()` and `seek()`, but it would also complicate things a lot (need to check if stream is seekable, etc). Should I care it at all?
* I don't like the name - can someone come up with something better than "RelativeStream" :) ?

Note that test suite is not finished - I will do it during the weekend.