### PR TITLE
Use php://temp instead of php://memory by default in Response

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -29,7 +29,7 @@ class Request implements RequestInterface
      * @param array $headers Headers for the message, if any.
      * @throws \InvalidArgumentException for any invalid value.
      */
-    public function __construct($uri = null, $method = null, $body = 'php://memory', array $headers = [])
+    public function __construct($uri = null, $method = null, $body = 'php://temp', array $headers = [])
     {
         $this->initialize($uri, $method, $body, $headers);
     }


### PR DESCRIPTION
Avoid problem of exceeded memory when dealing with large responses.