### PR TITLE
Raise exception on write() if stream is not writeable

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -224,7 +224,13 @@ class Stream implements StreamInterface
         $meta = stream_get_meta_data($this->resource);
         $mode = $meta['mode'];
 
-        return (strstr($mode, 'w') || strstr($mode, '+'));
+        return (
+            strstr($mode, 'x')
+            || strstr($mode, 'w')
+            || strstr($mode, 'c')
+            || strstr($mode, 'a')
+            || strstr($mode, '+')
+        );
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -297,7 +297,7 @@ class Stream implements StreamInterface
     public function getContents()
     {
         if (! $this->isReadable()) {
-            return '';
+            throw new RuntimeException('Stream is not readable');
         }
 
         $result = stream_get_contents($this->resource);

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -222,7 +222,9 @@ class Stream implements StreamInterface
         }
 
         $meta = stream_get_meta_data($this->resource);
-        return is_writable($meta['uri']);
+        $mode = $meta['mode'];
+
+        return (strstr($mode, 'w') || strstr($mode, '+'));
     }
 
     /**
@@ -232,6 +234,10 @@ class Stream implements StreamInterface
     {
         if (! $this->resource) {
             throw new RuntimeException('No resource available; cannot write');
+        }
+
+        if (! $this->isWritable()) {
+            throw new RuntimeException('Stream is not writable');
         }
 
         $result = fwrite($this->resource, $string);

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -246,6 +246,12 @@ class StreamTest extends TestCase
         $this->assertFalse($stream->isWritable());
     }
 
+    public function testIsWritableReturnsTrueForWritableMemoryStream()
+    {
+        $stream = new Stream("php://temp", "r+b");
+        $this->assertTrue($stream->isWritable());
+    }
+
     public function testWriteRaisesExceptionWhenStreamIsDetached()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');
@@ -254,6 +260,13 @@ class StreamTest extends TestCase
         $stream = new Stream($resource);
         $stream->detach();
         $this->setExpectedException('RuntimeException', 'No resource');
+        $stream->write('bar');
+    }
+
+    public function testWriteRaisesExceptionWhenStreamIsNotWritable()
+    {
+        $stream = new Stream('php://memory', 'r');
+        $this->setExpectedException('RuntimeException', 'Stream is not writable');
         $stream->write('bar');
     }
 

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -252,6 +252,105 @@ class StreamTest extends TestCase
         $this->assertTrue($stream->isWritable());
     }
 
+    public function provideDataForIsWritable()
+    {
+        return [
+            ['a',   true,  true],
+            ['a+',  true,  true],
+            ['a+b', true,  true],
+            ['ab',  true,  true],
+            ['c',   true,  true],
+            ['c+',  true,  true],
+            ['c+b', true,  true],
+            ['cb',  true,  true],
+            ['r',   true,  false],
+            ['r+',  true,  true],
+            ['r+b', true,  true],
+            ['rb',  true,  false],
+            ['rw',  true,  true],
+            ['w',   true,  true],
+            ['w+',  true,  true],
+            ['w+b', true,  true],
+            ['wb',  true,  true],
+            ['x',   false, true],
+            ['x+',  false, true],
+            ['x+b', false, true],
+            ['xb',  false, true],
+        ];
+    }
+
+    private function findNonExistentTempName()
+    {
+        while (true) {
+            $tmpnam = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'diac' . uniqid();
+            if (!file_exists(sys_get_temp_dir() . $tmpnam)) {
+                break;
+            }
+        }
+        return $tmpnam;
+    }
+
+    /**
+     * @dataProvider provideDataForIsWritable
+     */
+    public function testIsWritableReturnsCorrectFlagForMode($mode, $fileShouldExist, $flag)
+    {
+        if ($fileShouldExist) {
+            $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');
+            file_put_contents($this->tmpnam, 'FOO BAR');
+        } else {
+            // "x" modes REQUIRE that file doesn't exist, so we need to find random file name
+            $this->tmpnam = $this->findNonExistentTempName();
+        }
+        $resource = fopen($this->tmpnam, $mode);
+        $stream = new Stream($resource);
+        $this->assertEquals($flag, $stream->isWritable());
+    }
+
+    public function provideDataForIsReadable()
+    {
+        return [
+            ['a',   true,  false],
+            ['a+',  true,  true],
+            ['a+b', true,  true],
+            ['ab',  true,  false],
+            ['c',   true,  false],
+            ['c+',  true,  true],
+            ['c+b', true,  true],
+            ['cb',  true,  false],
+            ['r',   true,  true],
+            ['r+',  true,  true],
+            ['r+b', true,  true],
+            ['rb',  true,  true],
+            ['rw',  true,  true],
+            ['w',   true,  false],
+            ['w+',  true,  true],
+            ['w+b', true,  true],
+            ['wb',  true,  false],
+            ['x',   false, false],
+            ['x+',  false, true],
+            ['x+b', false, true],
+            ['xb',  false, false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDataForIsReadable
+     */
+    public function testIsReadableReturnsCorrectFlagForMode($mode, $fileShouldExist, $flag)
+    {
+        if ($fileShouldExist) {
+            $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');
+            file_put_contents($this->tmpnam, 'FOO BAR');
+        } else {
+            // "x" modes REQUIRE that file doesn't exist, so we need to find random file name
+            $this->tmpnam = $this->findNonExistentTempName();
+        }
+        $resource = fopen($this->tmpnam, $mode);
+        $stream = new Stream($resource);
+        $this->assertEquals($flag, $stream->isReadable());
+    }
+
     public function testWriteRaisesExceptionWhenStreamIsDetached()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -303,13 +303,14 @@ class StreamTest extends TestCase
         $this->assertEquals('', $stream->read(4096));
     }
 
-    public function testGetContentsReturnsEmptyStringIfStreamIsNotReadable()
+    public function testGetContentsRisesExceptionIfStreamIsNotReadable()
     {
         $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');
         file_put_contents($this->tmpnam, 'FOO BAR');
         $resource = fopen($this->tmpnam, 'w');
         $stream = new Stream($resource);
-        $this->assertEquals('', $stream->getContents());
+        $this->setExpectedException('RuntimeException');
+        $stream->getContents();
     }
 
     public function invalidResources()


### PR DESCRIPTION
Fixes #13.

I had to change how `isWritable` does the check, as `is_writable($meta['uri'])` is unreliable for TEMP and MEMORY streams.