### PR TITLE
Fix: Diactoros has actually just one dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install this library using composer:
 $ composer require zendframework/zend-diactoros
 ```
 
-`zend-diactoros` has the following dependencies (which are managed by Composer):
+`zend-diactoros` has the following dependency (which is managed by Composer):
 
 - `psr/http-message`, which defines interfaces for HTTP messages, including requests and responses. `zend-diactoros` provides implementations of each of these.
 


### PR DESCRIPTION
This PR

* [x] fixes `README.md`, as `zendframework/zend-diactoros` actually has just one dependency, not many