### PR TITLE
Fix: Add missing import

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -10,6 +10,7 @@
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * HTTP Request encapsulation


### PR DESCRIPTION
This PR

* [x] imports `StreamInterface`, which is used in the docblock for the constructor