### PR TITLE
Fix: Enviornment is spelled m-o-o-n

### DIFF
--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\UriInterface;
  * Server and client-side requests differ slightly in how the Host header is
  * handled; on client-side, it should be calculated on-the-fly from the
  * composed URI (if present), while on server-side, it will be calculated from
- * the enviornment. As such, this trait exists to provide the common code
+ * the environment. As such, this trait exists to provide the common code
  * between both client-side and server-side requests, and each can then
  * use the headers functionality required by their implementations.
  */


### PR DESCRIPTION
This PR

* [x] fixes a small typo (`enviornment` vs `environment`)