### PR TITLE
Fix: Add property annotations to class-level docblock

### DIFF
--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -23,6 +23,10 @@ use Psr\Http\Message\UriInterface;
  * the enviornment. As such, this trait exists to provide the common code
  * between both client-side and server-side requests, and each can then
  * use the headers functionality required by their implementations.
+ *
+ * @property array $headers
+ * @property array $headerNames
+ * @property StreamInterface $stream
  */
 trait RequestTrait
 {


### PR DESCRIPTION
This PR

* [x] adds `@property` annotations for fields which seem to be declared dynamically in `RequestTrait`, but are apparently declared in `MessageTrait`

:bulb: Not sure if this is right - is it?