### PR TITLE
Fix: Return static instead of self

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -66,7 +66,7 @@ trait MessageTrait
      * new protocol version.
      *
      * @param string $version HTTP protocol version
-     * @return self
+     * @return static
      */
     public function withProtocolVersion($version)
     {
@@ -184,7 +184,7 @@ trait MessageTrait
      *
      * @param string $header Case-insensitive header field name.
      * @param string|string[] $value Header value(s).
-     * @return self
+     * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
     public function withHeader($header, $value)
@@ -225,7 +225,7 @@ trait MessageTrait
      *
      * @param string $header Case-insensitive header field name to add.
      * @param string|string[] $value Header value(s).
-     * @return self
+     * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
     public function withAddedHeader($header, $value)
@@ -265,7 +265,7 @@ trait MessageTrait
      * the named header.
      *
      * @param string $header Case-insensitive header field name to remove.
-     * @return self
+     * @return static
      */
     public function withoutHeader($header)
     {
@@ -301,7 +301,7 @@ trait MessageTrait
      * new body stream.
      *
      * @param StreamInterface $body Body.
-     * @return self
+     * @return static
      * @throws \InvalidArgumentException When the body is not valid.
      */
     public function withBody(StreamInterface $body)

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -155,7 +155,7 @@ trait RequestTrait
      * @link http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
      *     request-target forms allowed in request messages)
      * @param mixed $requestTarget
-     * @return self
+     * @return static
      * @throws InvalidArgumentException if the request target is invalid.
      */
     public function withRequestTarget($requestTarget)
@@ -193,7 +193,7 @@ trait RequestTrait
      * changed request method.
      *
      * @param string $method Case-insensitive method.
-     * @return self
+     * @return static
      * @throws InvalidArgumentException for invalid HTTP methods.
      */
     public function withMethod($method)
@@ -241,7 +241,7 @@ trait RequestTrait
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
-     * @return self
+     * @return static
      */
     public function withUri(UriInterface $uri, $preserveHost = false)
     {


### PR DESCRIPTION
This PR

* [x] updates docblocks of `MessageTrait` and `ResponseTrait` to return `static` instead of `self`

:question: Seems to make more sense to me, how about you?