### PR TITLE
Remove methods declared as deprecated on 0.7.0

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -226,19 +226,6 @@ abstract class ServerRequestFactory
      * Marshal the URI from the $_SERVER array and headers
      *
      * @param array $server
-     * @param MessageInterface $request
-     * @return Uri
-     * @deprecated as of 0.7.0; use marshalUriFromServer() instead.
-     */
-    public static function marshalUri(array $server, MessageInterface $request)
-    {
-        return self::marshalUriFromServer($server, $request->getHeaders());
-    }
-
-    /**
-     * Marshal the URI from the $_SERVER array and headers
-     *
-     * @param array $server
      * @param array $headers
      * @return Uri
      */
@@ -283,20 +270,6 @@ abstract class ServerRequestFactory
         return $uri
             ->withPath($path)
             ->withQuery($query);
-    }
-
-    /**
-     * Marshal the host and port from HTTP headers and/or the PHP environment
-     *
-     * @param stdClass $accumulator
-     * @param array $server
-     * @param MessageInterface $request
-     * @return array Array with two members, host and port, at indices 0 and 1, respectively
-     * @deprecated as of 0.7.0; use marshalHostAndPortFromHeaders() instead.
-     */
-    public static function marshalHostAndPort(stdClass $accumulator, array $server, MessageInterface $request)
-    {
-        return self::marshalHostAndPortFromHeaders($accumulator, $server, $request->getHeaders());
     }
 
     /**

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -158,7 +158,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = $request->withHeader('Host', 'example.com');
 
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, [], $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, [], $request->getHeaders());
         $this->assertEquals('example.com', $accumulator->host);
         $this->assertNull($accumulator->port);
     }
@@ -171,7 +171,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = $request->withHeader('Host', 'example.com:8000');
 
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, [], $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, [], $request->getHeaders());
         $this->assertEquals('example.com', $accumulator->host);
         $this->assertEquals(8000, $accumulator->port);
     }
@@ -182,7 +182,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = $request->withUri(new Uri());
 
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, [], $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, [], $request->getHeaders());
         $this->assertEquals('', $accumulator->host);
         $this->assertNull($accumulator->port);
     }
@@ -196,7 +196,7 @@ class ServerRequestFactoryTest extends TestCase
             'SERVER_NAME' => 'example.com',
         ];
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, $server, $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, $server, $request->getHeaders());
         $this->assertEquals('example.com', $accumulator->host);
         $this->assertNull($accumulator->port);
     }
@@ -211,7 +211,7 @@ class ServerRequestFactoryTest extends TestCase
             'SERVER_PORT' => 8000,
         ];
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, $server, $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, $server, $request->getHeaders());
         $this->assertEquals('example.com', $accumulator->host);
         $this->assertEquals(8000, $accumulator->port);
     }
@@ -226,7 +226,7 @@ class ServerRequestFactoryTest extends TestCase
             'SERVER_NAME' => 'example.com',
         ];
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, $server, $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, $server, $request->getHeaders());
         $this->assertEquals('example.com', $accumulator->host);
     }
 
@@ -241,7 +241,7 @@ class ServerRequestFactoryTest extends TestCase
             'SERVER_PORT' => 8000,
         ];
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, $server, $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, $server, $request->getHeaders());
         $this->assertEquals('[FE80::0202:B3FF:FE1E:8329]', $accumulator->host);
         $this->assertEquals(8000, $accumulator->port);
     }
@@ -256,7 +256,7 @@ class ServerRequestFactoryTest extends TestCase
             'SERVER_NAME' => '[FE80::0202:B3FF:FE1E:8329:80]',
         ];
         $accumulator = (object) ['host' => '', 'port' => null];
-        ServerRequestFactory::marshalHostAndPort($accumulator, $server, $request);
+        ServerRequestFactory::marshalHostAndPortFromHeaders($accumulator, $server, $request->getHeaders());
         $this->assertEquals('[FE80::0202:B3FF:FE1E:8329]', $accumulator->host);
         $this->assertEquals(80, $accumulator->port);
     }
@@ -271,7 +271,7 @@ class ServerRequestFactoryTest extends TestCase
             'HTTPS' => true,
         ];
 
-        $uri = ServerRequestFactory::marshalUri($server, $request);
+        $uri = ServerRequestFactory::marshalUriFromServer($server, $request->getHeaders());
         $this->assertInstanceOf('Zend\Diactoros\Uri', $uri);
         $this->assertEquals('https', $uri->getScheme());
     }
@@ -286,7 +286,7 @@ class ServerRequestFactoryTest extends TestCase
             'HTTPS' => 'off',
         ];
 
-        $uri = ServerRequestFactory::marshalUri($server, $request);
+        $uri = ServerRequestFactory::marshalUriFromServer($server, $request->getHeaders());
         $this->assertInstanceOf('Zend\Diactoros\Uri', $uri);
         $this->assertEquals('http', $uri->getScheme());
     }
@@ -300,7 +300,7 @@ class ServerRequestFactoryTest extends TestCase
 
         $server  = [];
 
-        $uri = ServerRequestFactory::marshalUri($server, $request);
+        $uri = ServerRequestFactory::marshalUriFromServer($server, $request->getHeaders());
         $this->assertInstanceOf('Zend\Diactoros\Uri', $uri);
         $this->assertEquals('https', $uri->getScheme());
     }
@@ -315,7 +315,7 @@ class ServerRequestFactoryTest extends TestCase
             'REQUEST_URI' => '/foo/bar?foo=bar',
         ];
 
-        $uri = ServerRequestFactory::marshalUri($server, $request);
+        $uri = ServerRequestFactory::marshalUriFromServer($server, $request->getHeaders());
         $this->assertInstanceOf('Zend\Diactoros\Uri', $uri);
         $this->assertEquals('/foo/bar', $uri->getPath());
     }
@@ -331,7 +331,7 @@ class ServerRequestFactoryTest extends TestCase
             'QUERY_STRING' => 'bar=baz',
         ];
 
-        $uri = ServerRequestFactory::marshalUri($server, $request);
+        $uri = ServerRequestFactory::marshalUriFromServer($server, $request->getHeaders());
         $this->assertInstanceOf('Zend\Diactoros\Uri', $uri);
         $this->assertEquals('bar=baz', $uri->getQuery());
     }


### PR DESCRIPTION
ServerRequestFactory::marshalHostAndPort and ServerRequestFactory::marshalUriFromServer was declared as deprecated before the first stable release of the project.