### PR TITLE
Default values in ServerRequest

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -40,17 +40,17 @@ class ServerRequest implements ServerRequestInterface
     /**
      * @var array
      */
-    private $cookieParams;
+    private $cookieParams = [];
 
     /**
-     * @var array
+     * @var null|array|object
      */
     private $parsedBody;
 
     /**
      * @var array
      */
-    private $queryParams;
+    private $queryParams = [];
 
     /**
      * @var array

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -153,4 +153,33 @@ class ServerRequestTest extends TestCase
         $stream = $r->getValue($body);
         $this->assertEquals('php://memory', $stream);
     }
+
+    /**
+     * @group 46
+     */
+    public function testCookieParamsAreAnEmptyArrayAtInitialization()
+    {
+        $request = new ServerRequest();
+        $this->assertInternalType('array', $request->getCookieParams());
+        $this->assertCount(0, $request->getCookieParams());
+    }
+
+    /**
+     * @group 46
+     */
+    public function testQueryParamsAreAnEmptyArrayAtInitialization()
+    {
+        $request = new ServerRequest();
+        $this->assertInternalType('array', $request->getQueryParams());
+        $this->assertCount(0, $request->getQueryParams());
+    }
+
+    /**
+     * @group 46
+     */
+    public function testParsedBodyIsNullAtInitialization()
+    {
+        $request = new ServerRequest();
+        $this->assertNull($request->getParsedBody());
+    }
 }


### PR DESCRIPTION
I am using the symfony psr bridge currently, and there are a few problems because of missing default values in ServerRequest:

```php
    /**
     * @var array
     */
    private $cookieParams;

    /**
     * @var array
     */
    private $parsedBody;

    /**
     * @var array
     */
    private $queryParams;

    /**
     * @var array
     */
    private $serverParams;

    /**
     * @var array
     */
    private $uploadedFiles;
```

I can see in the construtor, that `$serverParams` and `$uploadedFiles` will be initialized. The `$attributes` have ben fixed here: https://github.com/zendframework/zend-diactoros/pull/9

But why are `$cookieParams`, `$parsedBody` and `$queryParams` by default NULL and not a empty array? This is not compatile with the api of ServerRequestInterface.