### PR TITLE
ResponseTrait

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -22,87 +22,7 @@ use Psr\Http\Message\StreamInterface;
  */
 class Response implements ResponseInterface
 {
-    use MessageTrait;
-
-    /**
-     * Map of standard HTTP status code/reason phrases
-     *
-     * @var array
-     */
-    private $phrases = [
-        // INFORMATIONAL CODES
-        100 => 'Continue',
-        101 => 'Switching Protocols',
-        102 => 'Processing',
-        // SUCCESS CODES
-        200 => 'OK',
-        201 => 'Created',
-        202 => 'Accepted',
-        203 => 'Non-Authoritative Information',
-        204 => 'No Content',
-        205 => 'Reset Content',
-        206 => 'Partial Content',
-        207 => 'Multi-status',
-        208 => 'Already Reported',
-        // REDIRECTION CODES
-        300 => 'Multiple Choices',
-        301 => 'Moved Permanently',
-        302 => 'Found',
-        303 => 'See Other',
-        304 => 'Not Modified',
-        305 => 'Use Proxy',
-        306 => 'Switch Proxy', // Deprecated
-        307 => 'Temporary Redirect',
-        // CLIENT ERROR
-        400 => 'Bad Request',
-        401 => 'Unauthorized',
-        402 => 'Payment Required',
-        403 => 'Forbidden',
-        404 => 'Not Found',
-        405 => 'Method Not Allowed',
-        406 => 'Not Acceptable',
-        407 => 'Proxy Authentication Required',
-        408 => 'Request Time-out',
-        409 => 'Conflict',
-        410 => 'Gone',
-        411 => 'Length Required',
-        412 => 'Precondition Failed',
-        413 => 'Request Entity Too Large',
-        414 => 'Request-URI Too Large',
-        415 => 'Unsupported Media Type',
-        416 => 'Requested range not satisfiable',
-        417 => 'Expectation Failed',
-        418 => 'I\'m a teapot',
-        422 => 'Unprocessable Entity',
-        423 => 'Locked',
-        424 => 'Failed Dependency',
-        425 => 'Unordered Collection',
-        426 => 'Upgrade Required',
-        428 => 'Precondition Required',
-        429 => 'Too Many Requests',
-        431 => 'Request Header Fields Too Large',
-        // SERVER ERROR
-        500 => 'Internal Server Error',
-        501 => 'Not Implemented',
-        502 => 'Bad Gateway',
-        503 => 'Service Unavailable',
-        504 => 'Gateway Time-out',
-        505 => 'HTTP Version not supported',
-        506 => 'Variant Also Negotiates',
-        507 => 'Insufficient Storage',
-        508 => 'Loop Detected',
-        511 => 'Network Authentication Required',
-    ];
-
-    /**
-     * @var string
-     */
-    private $reasonPhrase = '';
-
-    /**
-     * @var int
-     */
-    private $statusCode = 200;
+    use ResponseTrait;
 
     /**
      * @param string|resource|StreamInterface $stream Stream identifier and/or actual stream resource
@@ -130,60 +50,6 @@ class Response implements ResponseInterface
         list($this->headerNames, $headers) = $this->filterHeaders($headers);
         $this->assertHeaders($headers);
         $this->headers = $headers;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getStatusCode()
-    {
-        return $this->statusCode;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getReasonPhrase()
-    {
-        if (! $this->reasonPhrase
-            && isset($this->phrases[$this->statusCode])
-        ) {
-            $this->reasonPhrase = $this->phrases[$this->statusCode];
-        }
-
-        return $this->reasonPhrase;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function withStatus($code, $reasonPhrase = '')
-    {
-        $this->validateStatus($code);
-        $new = clone $this;
-        $new->statusCode   = (int) $code;
-        $new->reasonPhrase = $reasonPhrase;
-        return $new;
-    }
-
-    /**
-     * Validate a status code.
-     *
-     * @param int|string $code
-     * @throws InvalidArgumentException on an invalid status code.
-     */
-    private function validateStatus($code)
-    {
-        if (! is_numeric($code)
-            || is_float($code)
-            || $code < 100
-            || $code >= 600
-        ) {
-            throw new InvalidArgumentException(sprintf(
-                'Invalid status code "%s"; must be an integer between 100 and 599, inclusive',
-                (is_scalar($code) ? $code : gettype($code))
-            ));
-        }
     }
 
     /**

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use InvalidArgumentException;
+
+/**
+ * Trait implementing the various methods defined in ResponseInterface.
+ *
+ * @see https://github.com/php-fig/http-message/tree/master/src/ResponseInterface.php
+ */
+trait ResponseTrait
+{
+
+    use MessageTrait;
+
+    /**
+     * Map of standard HTTP status code/reason phrases
+     *
+     * @var array
+     */
+    private $phrases = [
+        // INFORMATIONAL CODES
+        100 => 'Continue',
+        101 => 'Switching Protocols',
+        102 => 'Processing',
+        // SUCCESS CODES
+        200 => 'OK',
+        201 => 'Created',
+        202 => 'Accepted',
+        203 => 'Non-Authoritative Information',
+        204 => 'No Content',
+        205 => 'Reset Content',
+        206 => 'Partial Content',
+        207 => 'Multi-status',
+        208 => 'Already Reported',
+        // REDIRECTION CODES
+        300 => 'Multiple Choices',
+        301 => 'Moved Permanently',
+        302 => 'Found',
+        303 => 'See Other',
+        304 => 'Not Modified',
+        305 => 'Use Proxy',
+        306 => 'Switch Proxy', // Deprecated
+        307 => 'Temporary Redirect',
+        // CLIENT ERROR
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        402 => 'Payment Required',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        405 => 'Method Not Allowed',
+        406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
+        408 => 'Request Time-out',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'Length Required',
+        412 => 'Precondition Failed',
+        413 => 'Request Entity Too Large',
+        414 => 'Request-URI Too Large',
+        415 => 'Unsupported Media Type',
+        416 => 'Requested range not satisfiable',
+        417 => 'Expectation Failed',
+        418 => 'I\'m a teapot',
+        422 => 'Unprocessable Entity',
+        423 => 'Locked',
+        424 => 'Failed Dependency',
+        425 => 'Unordered Collection',
+        426 => 'Upgrade Required',
+        428 => 'Precondition Required',
+        429 => 'Too Many Requests',
+        431 => 'Request Header Fields Too Large',
+        // SERVER ERROR
+        500 => 'Internal Server Error',
+        501 => 'Not Implemented',
+        502 => 'Bad Gateway',
+        503 => 'Service Unavailable',
+        504 => 'Gateway Time-out',
+        505 => 'HTTP Version not supported',
+        506 => 'Variant Also Negotiates',
+        507 => 'Insufficient Storage',
+        508 => 'Loop Detected',
+        511 => 'Network Authentication Required',
+    ];
+
+    /**
+     * @var string
+     */
+    private $reasonPhrase = '';
+
+    /**
+     * @var int
+     */
+    private $statusCode = 200;
+
+
+    /**
+     * Gets the response status code.
+     *
+     * The status code is a 3-digit integer result code of the server's attempt
+     * to understand and satisfy the request.
+     *
+     * @return int Status code.
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Gets the response reason phrase associated with the status code.
+     *
+     * Because a reason phrase is not a required element in a response
+     * status line, the reason phrase value MAY be null. Implementations MAY
+     * choose to return the default RFC 7231 recommended reason phrase (or those
+     * listed in the IANA HTTP Status Code Registry) for the response's
+     * status code.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @return string Reason phrase; must return an empty string if none present.
+     */
+    public function getReasonPhrase()
+    {
+        if (! $this->reasonPhrase
+            && isset($this->phrases[$this->statusCode])
+        ) {
+            $this->reasonPhrase = $this->phrases[$this->statusCode];
+        }
+
+        return $this->reasonPhrase;
+    }
+
+    /**
+     * Return an instance with the specified status code and, optionally, reason phrase.
+     *
+     * If no reason phrase is specified, implementations MAY choose to default
+     * to the RFC 7231 or IANA recommended reason phrase for the response's
+     * status code.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated status and reason phrase.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @param int $code The 3-digit integer result code to set.
+     * @param string $reasonPhrase The reason phrase to use with the
+     *     provided status code; if none is provided, implementations MAY
+     *     use the defaults as suggested in the HTTP specification.
+     * @return self
+     * @throws \InvalidArgumentException For invalid status code arguments.
+     */
+    public function withStatus($code, $reasonPhrase = '')
+    {
+        $this->validateStatus($code);
+        $new = clone $this;
+        $new->statusCode   = (int) $code;
+        $new->reasonPhrase = $reasonPhrase;
+        return $new;
+    }
+
+    /**
+     * Validate a status code.
+     *
+     * @param int|string $code
+     * @throws InvalidArgumentException on an invalid status code.
+     */
+    private function validateStatus($code)
+    {
+        if (! is_numeric($code)
+            || is_float($code)
+            || $code < 100
+            || $code >= 600
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid status code "%s"; must be an integer between 100 and 599, inclusive',
+                (is_scalar($code) ? $code : gettype($code))
+            ));
+        }
+    }
+}

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -25,52 +25,6 @@ class ResponseTest extends TestCase
         $this->response = new Response();
     }
 
-    public function testStatusCodeIs200ByDefault()
-    {
-        $this->assertEquals(200, $this->response->getStatusCode());
-    }
-
-    public function testStatusCodeMutatorReturnsCloneWithChanges()
-    {
-        $response = $this->response->withStatus(400);
-        $this->assertNotSame($this->response, $response);
-        $this->assertEquals(400, $response->getStatusCode());
-    }
-
-    public function invalidStatusCodes()
-    {
-        return [
-            'too-low' => [99],
-            'too-high' => [600],
-            'null' => [null],
-            'bool' => [true],
-            'string' => ['foo'],
-            'array' => [[200]],
-            'object' => [(object) [200]],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidStatusCodes
-     */
-    public function testCannotSetInvalidStatusCode($code)
-    {
-        $this->setExpectedException('InvalidArgumentException');
-        $response = $this->response->withStatus($code);
-    }
-
-    public function testReasonPhraseDefaultsToStandards()
-    {
-        $response = $this->response->withStatus(422);
-        $this->assertEquals('Unprocessable Entity', $response->getReasonPhrase());
-    }
-
-    public function testCanSetCustomReasonPhrase()
-    {
-        $response = $this->response->withStatus(422, 'Foo Bar!');
-        $this->assertEquals('Foo Bar!', $response->getReasonPhrase());
-    }
-
     public function testConstructorRaisesExceptionForInvalidStream()
     {
         $this->setExpectedException('InvalidArgumentException');
@@ -154,14 +108,7 @@ class ResponseTest extends TestCase
         $response = new Response('php://memory', null, $headers);
         $this->assertEquals($expected, $response->getHeaders());
     }
-
-    public function testReasonPhraseCanBeEmpty()
-    {
-        $response = $this->response->withStatus(599);
-        $this->assertInternalType('string', $response->getReasonPhrase());
-        $this->assertEmpty($response->getReasonPhrase());
-    }
-
+    
     public function headersWithInjectionVectors()
     {
         return [

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -108,7 +108,7 @@ class ResponseTest extends TestCase
         $response = new Response('php://memory', null, $headers);
         $this->assertEquals($expected, $response->getHeaders());
     }
-    
+
     public function headersWithInjectionVectors()
     {
         return [

--- a/test/ResponseTraitTest.php
+++ b/test/ResponseTraitTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Stream;
+
+class ResponseTraitTest extends TestCase
+{
+    /**
+     * @var Response
+    */
+    protected $response;
+
+    public function setUp()
+    {
+        $this->response = new Response($this->getMock('Psr\Http\Message\StreamInterface'));
+    }
+
+    public function testStatusCodeIs200ByDefault()
+    {
+        $this->assertEquals(200, $this->response->getStatusCode());
+    }
+
+    public function testStatusCodeMutatorReturnsCloneWithChanges()
+    {
+        $response = $this->response->withStatus(400);
+        $this->assertNotSame($this->response, $response);
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function invalidStatusCodes()
+    {
+        return [
+            'too-low' => [99],
+            'too-high' => [600],
+            'null' => [null],
+            'bool' => [true],
+            'string' => ['foo'],
+            'array' => [[200]],
+            'object' => [(object) [200]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidStatusCodes
+     */
+    public function testCannotSetInvalidStatusCode($code)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $response = $this->response->withStatus($code);
+    }
+
+    public function testReasonPhraseDefaultsToStandards()
+    {
+        $response = $this->response->withStatus(422);
+        $this->assertEquals('Unprocessable Entity', $response->getReasonPhrase());
+    }
+
+    public function testCanSetCustomReasonPhrase()
+    {
+        $response = $this->response->withStatus(422, 'Foo Bar!');
+        $this->assertEquals('Foo Bar!', $response->getReasonPhrase());
+    }
+
+    public function testReasonPhraseCanBeEmpty()
+    {
+        $response = $this->response->withStatus(599);
+        $this->assertInternalType('string', $response->getReasonPhrase());
+        $this->assertEmpty($response->getReasonPhrase());
+    }
+}


### PR DESCRIPTION
Moved related methods to a ResponseTrait
Using ResponseTrait, a class will implement the ResponseInterface
This basically allows for creating custom responses without the need to use the default Response constructor.