### PR TITLE
Add shortcut method for empty responses

### DIFF
--- a/src/Response/EmptyResponse.php
+++ b/src/Response/EmptyResponse.php
@@ -28,7 +28,7 @@ class EmptyResponse extends Response
         $body = new Stream('php://temp', 'r');
         parent::__construct($body, $status, $headers);
     }
-    
+
     /**
      * Create an empty response with the given headers.
      *

--- a/src/Response/EmptyResponse.php
+++ b/src/Response/EmptyResponse.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros\Response;
+
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Stream;
+
+/**
+ * A class representing empty HTTP responses.
+ */
+class EmptyResponse extends Response
+{
+    /**
+     * Create an empty response with the given status code.
+     *
+     * @param int $status Status code for the response, if any.
+     * @param array $headers Headers for the response, if any.
+     */
+    public function __construct($status = 204, array $headers = [])
+    {
+        $body = new Stream('php://temp', 'r');
+        parent::__construct($body, $status, $headers);
+    }
+    
+    /**
+     * Create an empty response with the given headers.
+     *
+     * @param array $headers Headers for the response.
+     * @return EmptyResponse
+     */
+    public static function withHeaders(array $headers)
+    {
+        return new static(204, $headers);
+    }
+}

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -61,6 +61,18 @@ final class StringResponse
     }
 
     /**
+     * Create an empty response with the given status code.
+     *
+     * @param int $status Status code for the response, if any.
+     * @param array $headers Headers for the response, if any.
+     * @return Response
+     */
+    public static function empty($status = 200, array $headers = [])
+    {
+        return static::createResponse('', $status, $headers);
+    }
+
+    /**
      * This class is non-instantiable.
      */
     private function __construct()
@@ -71,7 +83,7 @@ final class StringResponse
      * Create a Response from the provided information.
      *
      * Creates a Response using a php://temp stream, and writes the provided
-     * body to the stream; if non content-type header was provided, the given
+     * body to the stream; if no content-type header was provided, any given
      * $contentType is injected for it.
      *
      * @param string $body
@@ -80,12 +92,12 @@ final class StringResponse
      * @param string $contentType
      * @return Response
      */
-    private static function createResponse($body, $status, array $headers, $contentType)
+    private static function createResponse($body, $status, array $headers, $contentType = null)
     {
         $response = new Response('php://temp', $status, $headers);
         $response->getBody()->write($body);
 
-        if ($response->hasHeader('content-type')) {
+        if ($response->hasHeader('content-type') || $contentType === null) {
             return $response;
         }
 

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -83,7 +83,7 @@ final class StringResponse
      * Create a Response from the provided information.
      *
      * Creates a Response using a php://temp stream, and writes the provided
-     * body to the stream; if no content-type header was provided, any given
+     * body to the stream; if no content-type header was provided, the given
      * $contentType is injected for it.
      *
      * @param string $body
@@ -92,12 +92,12 @@ final class StringResponse
      * @param string $contentType
      * @return Response
      */
-    private static function createResponse($body, $status, array $headers, $contentType = null)
+    private static function createResponse($body, $status, array $headers, $contentType)
     {
         $response = new Response('php://temp', $status, $headers);
         $response->getBody()->write($body);
 
-        if ($contentType === null || $response->hasHeader('content-type')) {
+        if (empty($contentType) || $response->hasHeader('content-type')) {
             return $response;
         }
 

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -67,7 +67,7 @@ final class StringResponse
      * @param array $headers Headers for the response, if any.
      * @return Response
      */
-    public static function empty($status = 200, array $headers = [])
+    public static function blank($status = 200, array $headers = [])
     {
         return static::createResponse('', $status, $headers);
     }

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -97,7 +97,7 @@ final class StringResponse
         $response = new Response('php://temp', $status, $headers);
         $response->getBody()->write($body);
 
-        if ($response->hasHeader('content-type') || $contentType === null) {
+        if ($contentType === null || $response->hasHeader('content-type')) {
             return $response;
         }
 

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -67,7 +67,7 @@ final class StringResponse
      * @param array $headers Headers for the response, if any.
      * @return Response
      */
-    public static function blank($status = 200, array $headers = [])
+    public static function noContent($status = 204, array $headers = [])
     {
         return static::createResponse('', $status, $headers);
     }

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -61,18 +61,6 @@ final class StringResponse
     }
 
     /**
-     * Create an empty response with the given status code.
-     *
-     * @param int $status Status code for the response, if any.
-     * @param array $headers Headers for the response, if any.
-     * @return Response
-     */
-    public static function noContent($status = 204, array $headers = [])
-    {
-        return static::createResponse('', $status, $headers, null);
-    }
-
-    /**
      * This class is non-instantiable.
      */
     private function __construct()

--- a/src/Response/StringResponse.php
+++ b/src/Response/StringResponse.php
@@ -69,7 +69,7 @@ final class StringResponse
      */
     public static function noContent($status = 204, array $headers = [])
     {
-        return static::createResponse('', $status, $headers);
+        return static::createResponse('', $status, $headers, null);
     }
 
     /**

--- a/test/Response/EmptyResponseTest.php
+++ b/test/Response/EmptyResponseTest.php
@@ -21,7 +21,7 @@ class EmptyResponseTest extends TestCase
         $this->assertEquals('', (string) $response->getBody());
         $this->assertEquals(201, $response->getStatusCode());
     }
-    
+
     public function testHeaderConstructor()
     {
         $response = EmptyResponse::withHeaders(['x-empty' => ['true']]);

--- a/test/Response/EmptyResponseTest.php
+++ b/test/Response/EmptyResponseTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros\Response;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\Response\EmptyResponse;
+
+class EmptyResponseTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $response = new EmptyResponse(201);
+        $this->assertInstanceOf('Zend\Diactoros\Response', $response);
+        $this->assertEquals('', (string) $response->getBody());
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+    
+    public function testHeaderConstructor()
+    {
+        $response = EmptyResponse::withHeaders(['x-empty' => ['true']]);
+        $this->assertInstanceOf('Zend\Diactoros\Response', $response);
+        $this->assertEquals('', (string) $response->getBody());
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals('true', $response->getHeaderLine('x-empty'));
+    }
+}

--- a/test/Response/StringResponseTest.php
+++ b/test/Response/StringResponseTest.php
@@ -83,14 +83,6 @@ class StringResponseTest extends TestCase
         $this->assertSame(json_encode([$value], JSON_UNESCAPED_SLASHES), (string) $response->getBody());
     }
 
-    public function testNoContentConstructor()
-    {
-        $response = StringResponse::noContent();
-        $this->assertInstanceOf('Zend\Diactoros\Response', $response);
-        $this->assertEquals(204, $response->getStatusCode());
-        $this->assertEquals('', (string) $response->getBody());
-    }
-
     public function testContentTypeCanBeOverwritten()
     {
         $data = null;

--- a/test/Response/StringResponseTest.php
+++ b/test/Response/StringResponseTest.php
@@ -82,7 +82,7 @@ class StringResponseTest extends TestCase
         $this->assertEquals('application/json', $response->getHeaderLine('content-type'));
         $this->assertSame(json_encode([$value], JSON_UNESCAPED_SLASHES), (string) $response->getBody());
     }
-    
+
     public function testNoContentConstructor()
     {
         $response = StringResponse::noContent();

--- a/test/Response/StringResponseTest.php
+++ b/test/Response/StringResponseTest.php
@@ -82,6 +82,14 @@ class StringResponseTest extends TestCase
         $this->assertEquals('application/json', $response->getHeaderLine('content-type'));
         $this->assertSame(json_encode([$value], JSON_UNESCAPED_SLASHES), (string) $response->getBody());
     }
+    
+    public function testNoContentConstructor()
+    {
+        $response = StringResponse::noContent();
+        $this->assertInstanceOf('Zend\Diactoros\Response', $response);
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEquals('', (string) $response->getBody());
+    }
 
     public function testContentTypeCanBeOverwritten()
     {


### PR DESCRIPTION
`StringResponse::blank(401)`, as that's another common use case (though now `StringResponse` may not be perfect).

It's called `blank()` because `empty()` cannot be used as method name until PHP 7. Any better ideas?