### PR TITLE
Implement RedirectResponse

### DIFF
--- a/doc/book/custom-responses.md
+++ b/doc/book/custom-responses.md
@@ -17,6 +17,8 @@ Some standard use cases, however, make this un-wieldy:
 - Returning a response containing JSON; in this case, you likely want to provide the data to
   seriazlize to JSON, not a stream containing serialized JSON.
 - Returning a response with no content; in this case, you don't want to bother with the body at all.
+- Returning a redirect response; in this case, you likely just want to specify the target for the
+  `Location` header, and optionally the status code.
 
 Starting with version 1.1, Diactoros offers several custom response types and factories for
 simplifying these common tasks.
@@ -93,6 +95,34 @@ $response = new EmptyResponse(201, [
 
 // Alternately, set the header after instantiation:
 $response = ( new EmptyResponse(201) )->withHeader('Location', $url);
+```
+
+## Redirects
+
+`Zend\Diactoros\Response\RedirectResponse` is a `Zend\Diactoros\Response` extension for producing
+redirect responses. The only required argument is a URI, which may be provided as either a string or
+`Psr\Http\Message\UriInterface` instance. By default, the status 302 is used, and no other headers
+are produced; you may alter these via the additional optional arguments:
+
+```php
+class RedirectResponse extends Response
+{
+    public function __construct($uri, $status = 302, array $headers = []);
+}
+```
+
+Typical usage is:
+
+```php
+// 302 redirect:
+$response = new RedirectResponse('/user/login');
+
+// 301 redirect:
+$response = new RedirectResponse('/user/login', 301);
+
+// using a URI instance (e.g., by altering the request URI instance)
+$uri = $request->getUri();
+$response = new RedirectResponse($uri->withPath('/login'));
 ```
 
 ## Creating custom responses

--- a/src/Response/RedirectResponse.php
+++ b/src/Response/RedirectResponse.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros\Response;
+
+use Psr\Http\Message\UriInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Stream;
+
+/**
+ * Produce a redirect response.
+ */
+class RedirectResponse extends Response
+{
+    /**
+     * Create a redirect response.
+     *
+     * Produces a redirect response with a Location header and the given status
+     * (302 by default).
+     *
+     * Note: this method overwrites the `location` $headers value.
+     *
+     * @param string|UriInterface $uri URI for the Location header.
+     * @param int $status Integer status code for the redirect; 302 by default.
+     * @param array $headers Array of headers to use at initialization.
+     */
+    public function __construct($uri, $status = 302, array $headers = [])
+    {
+        if (! is_string($uri) && ! $uri instanceof UriInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'Uri provided to %s MUST be a string or Psr\Http\Message\UriInterface instance; received "%s"',
+                __CLASS__,
+                (is_object($uri) ? get_class($uri) : gettype($uri))
+            ));
+        }
+
+        $headers['location'] = [$uri];
+        parent::__construct('php://temp', $status, $headers);
+    }
+}

--- a/src/Response/RedirectResponse.php
+++ b/src/Response/RedirectResponse.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Diactoros\Response;
 
+use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;

--- a/test/Response/RedirectResponseTest.php
+++ b/test/Response/RedirectResponseTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros\Response;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\Response\RedirectResponse;
+use Zend\Diactoros\Uri;
+
+class RedirectResponseTest extends TestCase
+{
+    public function testConstructorAcceptsStringUriAndProduces302ResponseWithLocationHeader()
+    {
+        $response = new RedirectResponse('/foo/bar');
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertTrue($response->hasHeader('Location'));
+        $this->assertEquals('/foo/bar', $response->getHeaderLine('Location'));
+    }
+
+    public function testConstructorAcceptsUriInstanceAndProduces302ResponseWithLocationHeader()
+    {
+        $uri = new Uri('https://example.com:10082/foo/bar');
+        $response = new RedirectResponse($uri);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertTrue($response->hasHeader('Location'));
+        $this->assertEquals((string) $uri, $response->getHeaderLine('Location'));
+    }
+
+    public function testConstructorAllowsSpecifyingAlternateStatusCode()
+    {
+        $response = new RedirectResponse('/foo/bar', 301);
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertTrue($response->hasHeader('Location'));
+        $this->assertEquals('/foo/bar', $response->getHeaderLine('Location'));
+    }
+
+    public function testConstructorAllowsSpecifyingHeaders()
+    {
+        $response = new RedirectResponse('/foo/bar', 302, ['X-Foo' => ['Bar']]);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertTrue($response->hasHeader('Location'));
+        $this->assertEquals('/foo/bar', $response->getHeaderLine('Location'));
+        $this->assertTrue($response->hasHeader('X-Foo'));
+        $this->assertEquals('Bar', $response->getHeaderLine('X-Foo'));
+    }
+}

--- a/test/Response/RedirectResponseTest.php
+++ b/test/Response/RedirectResponseTest.php
@@ -49,4 +49,28 @@ class RedirectResponseTest extends TestCase
         $this->assertTrue($response->hasHeader('X-Foo'));
         $this->assertEquals('Bar', $response->getHeaderLine('X-Foo'));
     }
+
+    public function invalidUris()
+    {
+        return [
+            'null'       => [ null ],
+            'false'      => [ false ],
+            'true'       => [ true ],
+            'zero'       => [ 0 ],
+            'int'        => [ 1 ],
+            'zero-float' => [ 0.0 ],
+            'float'      => [ 1.1 ],
+            'array'      => [ [ '/foo/bar' ] ],
+            'object'     => [ (object) [ '/foo/bar' ] ],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidUris
+     * @expectedException InvalidArgumentException Uri
+     */
+    public function testConstructorRaisesExceptionOnInvalidUri($uri)
+    {
+        $response = new RedirectResponse($uri);
+    }
 }


### PR DESCRIPTION
Besides the HTML and JSON responses introduced in #52 and the empty response implemented in #58, the other most common server-side response type is a redirect. This pull request implements a `RedirectResponse`, which accepts a URI in order to produce a 302 response with a `Location` header. As per the other response types, this custom response type allow specifying an alternate status code and headers to use at initialization.

Examples as documented:

```php
// 302 redirect:
$response = new RedirectResponse('/user/login');

// 301 redirect:
$response = new RedirectResponse('/user/login', 301);

// using a URI instance (e.g., by altering the request URI instance)
$uri = $request->getUri();
$response = new RedirectResponse($uri->withPath('/login'));
```