### PR TITLE
Splitting StringResponse into many smaller classes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,4 +4,10 @@
             <directory>./test</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Response/HtmlResponse.php
+++ b/src/Response/HtmlResponse.php
@@ -9,6 +9,8 @@
 
 namespace Zend\Diactoros\Response;
 
+use InvalidArgumentException;
+use Psr\Http\Message\StreamInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 
@@ -29,17 +31,43 @@ class HtmlResponse extends Response
      * Produces an HTML response with a Content-Type of text/html and a default
      * status of 200.
      *
-     * @param string $html HTML for the message body.
+     * @param string|StreamInterface $html HTML or stream for the message body.
      * @param int $status Integer status code for the response; 200 by default.
      * @param array $headers Array of headers to use at initialization.
+     * @throws InvalidArgumentException if $html is neither a string or stream.
      */
     public function __construct($html, $status = 200, array $headers = [])
     {
+        parent::__construct(
+            $this->createBody($html),
+            $status,
+            $this->injectContentType('text/html', $headers)
+        );
+    }
+
+    /**
+     * Create the message body.
+     *
+     * @param string|StreamInterface $html
+     * @return StreamInterface
+     * @throws InvalidArgumentException if $html is neither a string or stream.
+     */
+    private function createBody($html)
+    {
+        if ($html instanceof StreamInterface) {
+            return $html;
+        }
+
+        if (! is_string($html)) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid content (%s) provided to %s',
+                (is_object($html) ? get_class($html) : gettype($html)),
+                __CLASS__
+            ));
+        }
+
         $body = new Stream('php://temp', 'wb+');
         $body->write($html);
-
-        $headers = $this->injectContentType('text/html', $headers);
-
-        parent::__construct($body, $status, $headers);
+        return $body;
     }
 }

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -65,6 +65,10 @@ class JsonResponse extends Response
      */
     private function jsonEncode($data, $encodingOptions)
     {
+        if (is_resource($data)) {
+            throw new InvalidArgumentException('Cannot JSON encode resources');
+        }
+
         if ($data === null) {
             // Use an ArrayObject to force an empty JSON object.
             $data = new ArrayObject();
@@ -80,7 +84,11 @@ class JsonResponse extends Response
         $json = json_encode($data, $encodingOptions);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new InvalidArgumentException(json_last_error_msg());
+            throw new InvalidArgumentException(sprintf(
+                'Unable to encode data to JSON in %s: %s',
+                __CLASS__,
+                json_last_error_msg()
+            ));
         }
 
         return $json;

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -10,6 +10,7 @@
 namespace Zend\Diactoros\Response;
 
 use ArrayObject;
+use InvalidArgumentException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 
@@ -30,13 +31,19 @@ class JsonResponse extends Response
      * If the data provided is null, an empty ArrayObject is used; if the data
      * is scalar, it is cast to an array prior to serialization.
      *
-     * Default JSON encoding is performed with JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT options
-     * (RFC4627-compliant JSON, which may also be embedded into HTML)
+     * Default JSON encoding is performed with the following options, which
+     * produces RFC4627-compliant JSON, capable of embedding into HTML.
+     *
+     * - JSON_HEX_TAG
+     * - JSON_HEX_APOS
+     * - JSON_HEX_AMP
+     * - JSON_HEX_QUOT options
      *
      * @param string $data Data to convert to JSON.
      * @param int $status Integer status code for the response; 200 by default.
      * @param array $headers Array of headers to use at initialization.
-     * @param int $encodingOptions The JSON encoding options
+     * @param int $encodingOptions JSON encoding options to use.
+     * @throws InvalidArgumentException if unable to encode the $data to JSON.
      */
     public function __construct($data, $status = 200, array $headers = [], $encodingOptions = 15)
     {
@@ -54,6 +61,7 @@ class JsonResponse extends Response
      * @param mixed $data
      * @param int $encodingOptions
      * @return string
+     * @throws InvalidArgumentException if unable to encode the $data to JSON.
      */
     private function jsonEncode($data, $encodingOptions)
     {
@@ -68,10 +76,11 @@ class JsonResponse extends Response
 
         // Clear json_last_error()
         json_encode(null);
+
         $json = json_encode($data, $encodingOptions);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new \InvalidArgumentException(json_last_error_msg());
+            throw new InvalidArgumentException(json_last_error_msg());
         }
 
         return $json;

--- a/test/Response/HtmlResponseTest.php
+++ b/test/Response/HtmlResponseTest.php
@@ -47,4 +47,36 @@ class HtmlResponseTest extends TestCase
         $this->assertEquals(404, $response->getStatusCode());
         $this->assertSame($body, (string) $response->getBody());
     }
+
+    public function testAllowsStreamsForResponseBody()
+    {
+        $stream = $this->prophesize('Psr\Http\Message\StreamInterface');
+        $body   = $stream->reveal();
+        $response = new HtmlResponse($body);
+        $this->assertSame($body, $response->getBody());
+    }
+
+    public function invalidHtmlContent()
+    {
+        return [
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'array'      => [['php://temp']],
+            'object'     => [(object) ['php://temp']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidHtmlContent
+     * @expectedException InvalidArgumentException
+     */
+    public function testRaisesExceptionforNonStringNonStreamBodyContent($body)
+    {
+        $response = new HtmlResponse($body);
+    }
 }

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -79,10 +79,25 @@ class JsonResponseTest extends TestCase
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testJsonErrorHandling()
+    public function testJsonErrorHandlingOfResources()
     {
         // Serializing something that is not serializable.
         $resource = fopen('php://memory', 'r');
         new JsonResponse($resource);
+    }
+
+    public function testJsonErrorHandlingOfBadEmbeddedData()
+    {
+        if (version_compare(PHP_VERSION, '5.5', 'lt')) {
+            $this->markTestSkipped('Skipped as PHP versions prior to 5.5 are noisy about JSON errors');
+        }
+
+        // Serializing something that is not serializable.
+        $data = [
+            'stream' => fopen('php://memory', 'r'),
+        ];
+
+        $this->setExpectedException('InvalidArgumentException', 'Unable to encode');
+        new JsonResponse($data);
     }
 }

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -82,7 +82,7 @@ class JsonResponseTest extends TestCase
     public function testJsonErrorHandling()
     {
         // Serializing something that is not serializable.
-        $resource = fopen("php://memory", "r");
+        $resource = fopen('php://memory', 'r');
         new JsonResponse($resource);
     }
 }

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -77,7 +77,7 @@ class JsonResponseTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException InvalidArgumentException
      */
     public function testJsonErrorHandling()
     {

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -92,6 +92,10 @@ class JsonResponseTest extends TestCase
             $this->markTestSkipped('Skipped as PHP versions prior to 5.5 are noisy about JSON errors');
         }
 
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Skipped as HHVM happily serializes embedded resources');
+        }
+
         // Serializing something that is not serializable.
         $data = [
             'stream' => fopen('php://memory', 'r'),


### PR DESCRIPTION
I would like to suggest splitting the new `StringResponse` into 2 smaller classes: `JsonResponse` and `HtmlResponse`.

Here is the rationale:

`StringResponse` is actually a `StringResponseFactory`. It is final, so it cannot be extended, and it provides only 2 static methods: `html` and `json`. However, there are a bunch of other perfectly viable responses that are also "strings". For instance, why is there no `xml` method? As time goes by, it is likely that this class will start growing and growing up to the point where it is not maintainable anymore.

Also, yesterday, I tried to implement my own response. I ended up copy-pasting the `createResponse` method in my own class. I think this method is very valuable and should be exposed.

Would you be ok if I submit a pull request splitting `StringResponse` like this:

```
$htmlResponse = HtmlResponse::create($html, $status, $headers);

$jsonResponse = JsonResponse::create($html, $status, $headers);
```

Both `JsonResponse` and `HtmlResponse` may extend an abstract `StringResponse` that provides a protected `createResponse` method.

Does it make sense? Shall I work on a pull-request about this?