### PR TITLE
Remove casting prior to JSON serialization

### DIFF
--- a/doc/book/custom-responses.md
+++ b/doc/book/custom-responses.md
@@ -52,9 +52,8 @@ the `Content-Type` header to `application/json`:
 $response = new JsonResponse($data);
 ```
 
-If a null value is provide, an empty JSON object is used for the content. Scalar data is cast to an
-array before serialization. If providing an object, we recommend implementing
-[JsonSerializable](http://php.net/JsonSerializable) to ensure your object is correctly serialized.
+If providing an object, we recommend implementing [JsonSerializable](http://php.net/JsonSerializable)
+to ensure your object is correctly serialized.
 
 Just like the `HtmlResponse`, the `JsonResponse` allows passing two additional arguments — a
 status code, and an array of headers — to allow you to further seed the initial state of the

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -9,27 +9,23 @@
 
 namespace Zend\Diactoros\Response;
 
-use ArrayObject;
 use InvalidArgumentException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 
 /**
- * HTML response.
+ * JSON response.
  *
- * Allows creating a response by passing an HTML string to the constructor;
- * by default, sets a status code of 200 and sets the Content-Type header to
- * text/html.
+ * Allows creating a response by passing data to the constructor; by default,
+ * serializes the data to JSON, sets a status code of 200 and sets the
+ * Content-Type header to application/json.
  */
 class JsonResponse extends Response
 {
     use InjectContentTypeTrait;
 
     /**
-     * Create a JSON response with the given array of data.
-     *
-     * If the data provided is null, an empty ArrayObject is used; if the data
-     * is scalar, it is cast to an array prior to serialization.
+     * Create a JSON response with the given data.
      *
      * Default JSON encoding is performed with the following options, which
      * produces RFC4627-compliant JSON, capable of embedding into HTML.
@@ -67,15 +63,6 @@ class JsonResponse extends Response
     {
         if (is_resource($data)) {
             throw new InvalidArgumentException('Cannot JSON encode resources');
-        }
-
-        if ($data === null) {
-            // Use an ArrayObject to force an empty JSON object.
-            $data = new ArrayObject();
-        }
-
-        if (is_scalar($data)) {
-            $data = (array) $data;
         }
 
         // Clear json_last_error()

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -31,17 +31,10 @@ class JsonResponseTest extends TestCase
         $this->assertSame($json, (string) $response->getBody());
     }
 
-    public function testNullValuePassedToConstructorRendersEmptyJsonObjectInBody()
-    {
-        $response = new JsonResponse(null);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('application/json', $response->getHeaderLine('content-type'));
-        $this->assertSame('{}', (string) $response->getBody());
-    }
-
     public function scalarValuesForJSON()
     {
         return [
+            'null'         => [null],
             'false'        => [false],
             'true'         => [true],
             'zero'         => [0],
@@ -56,12 +49,13 @@ class JsonResponseTest extends TestCase
     /**
      * @dataProvider scalarValuesForJSON
      */
-    public function testScalarValuePassedToConstructorRendersValueWithinJSONArray($value)
+    public function testScalarValuePassedToConstructorJsonEncodesDirectly($value)
     {
         $response = new JsonResponse($value);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('application/json', $response->getHeaderLine('content-type'));
-        $this->assertSame(json_encode([$value], JSON_UNESCAPED_SLASHES), (string) $response->getBody());
+        // 15 is the default mask used by JsonResponse
+        $this->assertSame(json_encode($value, 15), (string) $response->getBody());
     }
 
     public function testCanProvideStatusCodeToConstructor()


### PR DESCRIPTION
As noted on #63, casting nulls and scalars to objects and arrays, respectively, is not necessary, and likely unwanted; it could even be considered buggy behavior.

This patch eliminates the casting entirely, and updates the tests to ensure that scalars are encoded verbatim.