### PR TITLE
Stream class accept all resource types

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -35,23 +35,7 @@ class Stream implements StreamInterface
      */
     public function __construct($stream, $mode = 'r')
     {
-        $this->stream = $stream;
-
-        if (is_resource($stream)) {
-            $this->resource = $stream;
-        } elseif (is_string($stream)) {
-            set_error_handler(function ($errno, $errstr) {
-                throw new InvalidArgumentException(
-                    'Invalid file provided for stream; must be a valid path with valid permissions'
-                );
-            }, E_WARNING);
-            $this->resource = fopen($stream, $mode);
-            restore_error_handler();
-        } else {
-            throw new InvalidArgumentException(
-                'Invalid stream provided; must be a string stream identifier or resource'
-            );
-        }
+        $this->setStream($stream, $mode);
     }
 
     /**
@@ -105,26 +89,7 @@ class Stream implements StreamInterface
      */
     public function attach($resource, $mode = 'r')
     {
-        $error = null;
-        if (! is_resource($resource) && is_string($resource)) {
-            set_error_handler(function ($e) use (&$error) {
-                $error = $e;
-            }, E_WARNING);
-            $resource = fopen($resource, $mode);
-            restore_error_handler();
-        }
-
-        if ($error) {
-            throw new InvalidArgumentException('Invalid stream reference provided');
-        }
-
-        if (! is_resource($resource)) {
-            throw new InvalidArgumentException(
-                'Invalid stream provided; must be a string stream identifier or resource'
-            );
-        }
-
-        $this->resource = $resource;
+        $this->setStream($resource, $mode);
     }
 
     /**
@@ -322,5 +287,42 @@ class Stream implements StreamInterface
         }
 
         return $metadata[$key];
+    }
+
+    /**
+     * Set the internal stream resource.
+     *
+     * @param string|resource $stream String stream target or stream resource.
+     * @param string $mode Resource mode for stream target.
+     * @throws InvalidArgumentException for invalid streams or resources.
+     */
+    private function setStream($stream, $mode = 'r')
+    {
+        $error    = null;
+        $resource = $stream;
+
+        if (is_string($stream)) {
+            set_error_handler(function ($e) use (&$error) {
+                $error = $e;
+            }, E_WARNING);
+            $resource = fopen($stream, $mode);
+            restore_error_handler();
+        }
+
+        if ($error) {
+            throw new InvalidArgumentException('Invalid stream reference provided');
+        }
+
+        if (! is_resource($resource) || 'stream' !== get_resource_type($resource)) {
+            throw new InvalidArgumentException(
+                'Invalid stream provided; must be a string stream identifier or stream resource'
+            );
+        }
+
+        if ($stream !== $resource) {
+            $this->stream = $stream;
+        }
+
+        $this->resource = $resource;
     }
 }

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -539,4 +539,55 @@ class StreamTest extends TestCase
         $stream = new Stream($resource);
         $this->assertEquals($expected['size'], $stream->getSize());
     }
+
+    /**
+     * @group 67
+     */
+    public function testRaisesExceptionOnConstructionForNonStreamResources()
+    {
+        $resource = $this->getResourceFor67();
+        if (false === $resource) {
+            $this->markTestSkipped('No acceptable resource available to test ' . __METHOD__);
+        }
+
+        $this->setExpectedException('InvalidArgumentException', 'stream');
+        new Stream($resource);
+    }
+
+    /**
+     * @group 67
+     */
+    public function testRaisesExceptionOnAttachForNonStreamResources()
+    {
+        $resource = $this->getResourceFor67();
+        if (false === $resource) {
+            $this->markTestSkipped('No acceptable resource available to test ' . __METHOD__);
+        }
+
+        $stream = new Stream(__FILE__);
+
+        $this->setExpectedException('InvalidArgumentException', 'stream');
+        $stream->attach($resource);
+    }
+
+    public function getResourceFor67()
+    {
+        if (function_exists('curl_init')) {
+            return curl_init();
+        }
+
+        if (function_exists('shmop_open')) {
+            return shmop_open(ftok(__FILE__, 't'), 'c', 0644, 100);
+        }
+
+        if (function_exists('gmp_init')) {
+            return gmp_init(1);
+        }
+
+        if (function_exists('imagecreate')) {
+            return imagecreate(200, 200);
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
Problem:
Stream accept resource, not only stream resource.
You can initialize stream class with wrong parameter.

Simple(bad) test:

```php
    public function testCanNotInstantiateWithStreamIdentifier()
    {
        $true = false;
        $image = imagecreate(200, 200);

        try {
            $this->stream = new Stream($image, 'wb+');
        } catch(\Exception $e)
        {
            $true = true;
        }

        $this->assertTrue($true); //test is red
    }
```

Simple (not that bad) solution.

```php
        if (is_resource($stream)) {
            $type = get_resource_type($stream);
            if($type !== 'stream')
            {
                throw new \InvalidArgumentException("Resource is not a stream");
            }
            $this->resource = $stream;
        } elseif (is_string($stream)) {
```
