### PR TITLE
[#80] Ensure `Uri::with*()` methods validate

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -220,6 +220,14 @@ class Uri implements UriInterface
      */
     public function withScheme($scheme)
     {
+        if (! is_string($scheme)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a string argument; received %s',
+                __METHOD__,
+                (is_object($scheme) ? get_class($scheme) : gettype($scheme))
+            ));
+        }
+
         $scheme = $this->filterScheme($scheme);
 
         if ($scheme === $this->scheme) {
@@ -238,6 +246,21 @@ class Uri implements UriInterface
      */
     public function withUserInfo($user, $password = null)
     {
+        if (! is_string($user)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a string user argument; received %s',
+                __METHOD__,
+                (is_object($user) ? get_class($user) : gettype($user))
+            ));
+        }
+        if (null !== $password && ! is_string($password)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a string password argument; received %s',
+                __METHOD__,
+                (is_object($password) ? get_class($password) : gettype($password))
+            ));
+        }
+
         $info = $user;
         if ($password) {
             $info .= ':' . $password;
@@ -259,6 +282,14 @@ class Uri implements UriInterface
      */
     public function withHost($host)
     {
+        if (! is_string($host)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a string argument; received %s',
+                __METHOD__,
+                (is_object($host) ? get_class($host) : gettype($host))
+            ));
+        }
+
         if ($host === $this->host) {
             // Do nothing if no change was made.
             return clone $this;
@@ -373,6 +404,14 @@ class Uri implements UriInterface
      */
     public function withFragment($fragment)
     {
+        if (! is_string($fragment)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a string argument; received %s',
+                __METHOD__,
+                (is_object($fragment) ? get_class($fragment) : gettype($fragment))
+            ));
+        }
+
         $fragment = $this->filterFragment($fragment);
 
         if ($fragment === $this->fragment) {
@@ -585,10 +624,6 @@ class Uri implements UriInterface
      */
     private function filterFragment($fragment)
     {
-        if (null === $fragment) {
-            $fragment = '';
-        }
-
         if (! empty($fragment) && strpos($fragment, '#') === 0) {
             $fragment = substr($fragment, 1);
         }

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -455,4 +455,49 @@ class UriTest extends TestCase
         $uri = new Uri($url);
         $this->assertEquals('http://example.org/zend.com', (string) $uri);
     }
+
+    public function invalidStringComponentValues()
+    {
+        $methods = [
+            'withScheme',
+            'withUserInfo',
+            'withHost',
+            'withPath',
+            'withQuery',
+            'withFragment',
+        ];
+
+        $values = [
+            'null'       => null,
+            'true'       => true,
+            'false'      => false,
+            'zero'       => 0,
+            'int'        => 1,
+            'zero-float' => 0.0,
+            'float'      => 1.1,
+            'array'      => ['value'],
+            'object'     => (object)['value' => 'value'],
+        ];
+
+        $combinations = [];
+        foreach ($methods as $method) {
+            foreach ($values as $type => $value) {
+                $key = sprintf('%s-%s', $method, $type);
+                $combinations[$key] = [$method, $value];
+            }
+        }
+
+        return $combinations;
+    }
+
+    /**
+     * @group 80
+     * @dataProvider invalidStringComponentValues
+     */
+    public function testPassingInvalidValueToWithMethodRaisesException($method, $value)
+    {
+        $uri = new Uri('https://example.com/');
+        $this->setExpectedException('InvalidArgumentException');
+        $uri->$method($value);
+    }
 }


### PR DESCRIPTION
If methods should only accept a string, ensure they raise an exception in such cases.

This affects `withFragment()`, `withScheme()`, `withUserInfo()`, and `withHost()`, each of which were previously passing non-string input through without change, and, in some cases, raising errors as a result, while in other cases casting to string in unexpected ways.

Since PSR-7 documents these methods as only accepting strings, raising an `InvalidArgumentException` for non-string input is a reasonable and consistent approach.

Fixes #80.