### PR TITLE
[#82] Ensure `moveTo()` works in non-SAPI environments

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -223,9 +223,10 @@ class UploadedFile implements UploadedFileInterface
             throw new RuntimeException('Unable to write to designated path');
         }
 
-        $this->stream->rewind();
-        while (! $this->stream->eof()) {
-            fwrite($handle, $this->stream->read(4096));
+        $stream = $this->getStream();
+        $stream->rewind();
+        while (! $stream->eof()) {
+            fwrite($handle, $stream->read(4096));
         }
 
         fclose($handle);

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -270,4 +270,20 @@ class UploadedFileTest extends TestCase
         $this->setExpectedException('RuntimeException', 'upload error');
         $stream = $uploadedFile->getStream();
     }
+
+    /**
+     * @group 82
+     */
+    public function testMoveToCreatesStreamIfOnlyAFilenameWasProvided()
+    {
+        $this->tmpFile = tempnam(sys_get_temp_dir(), 'DIA');
+
+        $uploadedFile = new UploadedFile(__FILE__, 100, UPLOAD_ERR_OK, basename(__FILE__), 'text/plain');
+        $uploadedFile->moveTo($this->tmpFile);
+
+        $original = file_get_contents(__FILE__);
+        $test     = file_get_contents($this->tmpFile);
+
+        $this->assertEquals($original, $test);
+    }
 }


### PR DESCRIPTION
Updates `writeFile()` to call `getStream()` instead of assuming `$stream` is already populated correctly; this ensures that if a filename, and not a stream or resource, was provided to the constructor, the file can still be correctly moved.

Fixes #82