### PR TITLE
Set the Content-Length header when emitting the response

### DIFF
--- a/src/Response/SapiEmitter.php
+++ b/src/Response/SapiEmitter.php
@@ -29,6 +29,10 @@ class SapiEmitter implements EmitterInterface
             throw new RuntimeException('Unable to emit response; headers already sent');
         }
 
+        if (! $response->hasHeader('Content-Length')) {
+            $response = $response->withHeader('Content-Length', (string) $response->getBody()->getSize());
+        }
+
         $this->emitStatusLine($response);
         $this->emitHeaders($response);
         $this->emitBody($response, $maxBufferLevel);

--- a/test/Response/SapiEmitterTest.php
+++ b/test/Response/SapiEmitterTest.php
@@ -12,7 +12,6 @@ namespace ZendTest\Diactoros\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\SapiEmitter;
-use Zend\Diactoros\Stream;
 use ZendTest\Diactoros\TestAsset\HeaderStack;
 
 class SapiEmitterTest extends TestCase
@@ -45,6 +44,7 @@ class SapiEmitterTest extends TestCase
         ob_end_clean();
         $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
         $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
+        $this->assertContains('Content-Length: 8', HeaderStack::stack());
     }
 
     public function testEmitsMessageBody()

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Server;
+use Zend\Diactoros\Stream;
 use ZendTest\Diactoros\TestAsset\HeaderStack;
 
 class ServerTest extends TestCase
@@ -252,6 +253,16 @@ class ServerTest extends TestCase
             ->expects($this->once())
             ->method('getHeaders')
             ->will($this->returnValue([]));
+
+        $responseBody = new Stream('php://temp');
+        $this->response
+            ->expects($this->any())
+            ->method('getBody')
+            ->willReturn($responseBody);
+        $this->response
+            ->expects($this->any())
+            ->method('withHeader')
+            ->willReturnSelf();
 
         $final = function ($req, $res, $err = null) use ($phpunit, $request, $response, &$invoked) {
             $phpunit->assertSame($request, $req);

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -230,6 +230,7 @@ class ServerTest extends TestCase
      */
     public function testHeaderOrderIsHonoredWhenEmitted($stack)
     {
+        array_pop($stack); // ignore "Content-Length" automatically set by the response emitter
         $header = array_pop($stack);
         $this->assertContains(
             'Set-Cookie: bar=baz; expires=Wed, 8 Oct 2014 10:30; path=/foo/bar; domain=example.com',


### PR DESCRIPTION
Fixes #84

One test is failing because of a side-effect in unrelated tests. Need to work on it, but if you have an idea on the best way to fix it's welcome, I'm not familiar with everything yet.