### PR TITLE
added CallbackStream

### DIFF
--- a/src/CallbackStream.php
+++ b/src/CallbackStream.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Oscar Otero (http://oscarotero.com) / Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Implementation of PSR HTTP streams
+ */
+class CallbackStream implements StreamInterface
+{
+    /**
+     * @var callable|null
+     */
+    protected $callback;
+
+    /**
+     * @param callable $callback
+     * @throws InvalidArgumentException
+     */
+    public function __construct(callable $callback)
+    {
+        $this->attach($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->getContents();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        $this->callback = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function detach()
+    {
+        $callback = $this->callback;
+        $this->callback = null;
+        return $callback;
+    }
+
+    /**
+     * Attach a new callback to the instance.
+     *
+     * @param callable $callback
+     * @throws InvalidArgumentException for callable callback
+     */
+    public function attach(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tell()
+    {
+        throw new RuntimeException('Callback streams cannot tell position');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eof()
+    {
+        return empty($this->callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new RuntimeException('Callback streams cannot seek position');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        throw new RuntimeException('Callback streams cannot rewind position');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($string)
+    {
+        throw new RuntimeException('Callback streams cannot write');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($length)
+    {
+        throw new RuntimeException('Callback streams cannot read');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContents()
+    {
+        $callback = $this->detach();
+
+        return $callback ? $callback() : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($key = null)
+    {
+        $metadata = [
+            'eof' => $this->eof(),
+            'stream_type' => 'callback',
+            'seekable' => false
+        ];
+
+        if (null === $key) {
+            return $metadata;
+        }
+
+        if (! array_key_exists($key, $metadata)) {
+            return null;
+        }
+
+        return $metadata[$key];
+    }
+}

--- a/test/CallbackStreamTest.php
+++ b/test/CallbackStreamTest.php
@@ -3,7 +3,7 @@
  * Zend Framework (http://framework.zend.com/)
  *
  * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015 Oscar Otero (http://oscarotero.com) / 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015 Oscar Otero (http://oscarotero.com) / Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/CallbackStreamTest.php
+++ b/test/CallbackStreamTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Oscar Otero (http://oscarotero.com) / 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Diactoros\RelativeStream;
+use Zend\Diactoros\CallbackStream;
+
+/**
+ * @covers \Zend\Diactoros\CallbackStream
+ */
+class CallbackStreamTest extends TestCase
+{
+    public function testToString()
+    {
+        $stream = new CallbackStream(function () {
+            return 'foobarbaz';
+        });
+
+        $ret = $stream->__toString();
+        $this->assertEquals('foobarbaz', $ret);
+    }
+
+    public function testClose()
+    {
+        $stream = new CallbackStream(function () {});
+
+        $stream->close();
+
+        $callback = $stream->detach();
+
+        $this->assertNull($callback);
+    }
+
+    public function testDetach()
+    {
+        $callback = function () {};
+        $stream = new CallbackStream($callback);
+        $ret = $stream->detach();
+        $this->assertSame($callback, $ret);
+    }
+
+    public function testEof()
+    {
+        $stream = new CallbackStream(function () {});
+        $ret = $stream->eof();
+        $this->assertFalse($ret);
+
+        $stream->getContents();
+        $ret = $stream->eof();
+        $this->assertTrue($ret);
+    }
+
+    public function testGetSize()
+    {
+        $stream = new CallbackStream(function () {});
+        $ret = $stream->getSize();
+        $this->assertNull($ret);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testTell()
+    {
+        $stream = new CallbackStream(function () {});
+        $stream->tell();
+    }
+
+    public function testIsSeekable()
+    {
+        $stream = new CallbackStream(function () {});
+        $ret = $stream->isSeekable();
+        $this->assertFalse($ret);
+    }
+
+    public function testIsWritable()
+    {
+        $stream = new CallbackStream(function () {});
+        $ret = $stream->isWritable();
+        $this->assertFalse($ret);
+    }
+
+    public function testIsReadable()
+    {
+        $stream = new CallbackStream(function () {});
+        $ret = $stream->isReadable();
+        $this->assertFalse($ret);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testSeek()
+    {
+        $stream = new CallbackStream(function () {});
+        $stream->seek(0);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testRewind()
+    {
+        $stream = new CallbackStream(function () {});
+        $stream->rewind();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testWrite()
+    {
+        $stream = new CallbackStream(function () {});
+        $stream->write('foobarbaz');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testRead()
+    {
+        $stream = new CallbackStream(function () {});
+        $stream->read(3);
+    }
+
+    public function testGetContents()
+    {
+        $stream = new CallbackStream(function () {
+            return 'foobarbaz';
+        });
+
+        $ret = $stream->getContents();
+        $this->assertEquals('foobarbaz', $ret);
+    }
+
+    public function testGetMetadata()
+    {
+        $stream = new CallbackStream(function () {});
+
+        $ret = $stream->getMetadata('stream_type');
+        $this->assertEquals('callback', $ret);
+
+        $ret = $stream->getMetadata('seekable');
+        $this->assertFalse($ret);
+
+        $ret = $stream->getMetadata('eof');
+        $this->assertFalse($ret);
+    }
+}

--- a/test/CallbackStreamTest.php
+++ b/test/CallbackStreamTest.php
@@ -30,7 +30,8 @@ class CallbackStreamTest extends TestCase
 
     public function testClose()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
 
         $stream->close();
 
@@ -41,7 +42,8 @@ class CallbackStreamTest extends TestCase
 
     public function testDetach()
     {
-        $callback = function () {};
+        $callback = function () {
+        };
         $stream = new CallbackStream($callback);
         $ret = $stream->detach();
         $this->assertSame($callback, $ret);
@@ -49,7 +51,8 @@ class CallbackStreamTest extends TestCase
 
     public function testEof()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $ret = $stream->eof();
         $this->assertFalse($ret);
 
@@ -60,7 +63,8 @@ class CallbackStreamTest extends TestCase
 
     public function testGetSize()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $ret = $stream->getSize();
         $this->assertNull($ret);
     }
@@ -70,27 +74,31 @@ class CallbackStreamTest extends TestCase
      */
     public function testTell()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $stream->tell();
     }
 
     public function testIsSeekable()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $ret = $stream->isSeekable();
         $this->assertFalse($ret);
     }
 
     public function testIsWritable()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $ret = $stream->isWritable();
         $this->assertFalse($ret);
     }
 
     public function testIsReadable()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $ret = $stream->isReadable();
         $this->assertFalse($ret);
     }
@@ -100,7 +108,8 @@ class CallbackStreamTest extends TestCase
      */
     public function testSeek()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $stream->seek(0);
     }
 
@@ -109,7 +118,8 @@ class CallbackStreamTest extends TestCase
      */
     public function testRewind()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $stream->rewind();
     }
 
@@ -118,7 +128,8 @@ class CallbackStreamTest extends TestCase
      */
     public function testWrite()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $stream->write('foobarbaz');
     }
 
@@ -127,7 +138,8 @@ class CallbackStreamTest extends TestCase
      */
     public function testRead()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
         $stream->read(3);
     }
 
@@ -143,7 +155,8 @@ class CallbackStreamTest extends TestCase
 
     public function testGetMetadata()
     {
-        $stream = new CallbackStream(function () {});
+        $stream = new CallbackStream(function () {
+        });
 
         $ret = $stream->getMetadata('stream_type');
         $this->assertEquals('callback', $ret);


### PR DESCRIPTION
Hello.
This is a implementation of Stream that uses a callback as described in #70 
Maybe should be great to add support for generators, to allow doing thinks like this:
```php
$stream = new CallbackStream(function () {
    $command = new Command();
    $command->run();

    while ($command->isRunning()) {
        yield $command->getOutput(); //returns always a string
    }
    return false; //end of the command
});
```
In this case, the emitter should iterate with the stream, instead return all content at once. I mean:
```php
while (!$stream->eof()) {
    echo $stream->read(1);
};
```
This behaviour is not implemented (currently `$stream->read()` throws a `RuntimeException` and the callback can be executed only once), but I can do it if you like.