### PR TITLE
Duplicate "Host" header when using "RequestTrait::withUri" method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#96](https://github.com/zendframework/zend-diactoros/pull/96) updates
   `withPort()` to allow `null` port values (indicating usage of default for
   the given scheme).
+- [#91](https://github.com/zendframework/zend-diactoros/pull/91) fixes the
+  logic of `withUri()` to do a case-insensitive check for an existing `Host`
+  header, replacing it with the new one.
 
 ## 1.1.3 - 2015-08-10
 

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -249,6 +249,16 @@ trait RequestTrait
         }
 
         $new->headerNames['host'] = 'Host';
+
+        // Remove an existing host header if present, regardless of current
+        // de-normalization of the header name.
+        // @see https://github.com/zendframework/zend-diactoros/issues/91
+        foreach (array_keys($new->headers) as $header) {
+            if (strtolower($header) === 'host') {
+                unset($new->headers[$header]);
+            }
+        }
+
         $new->headers['Host'] = [$host];
 
         return $new;

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -455,4 +455,46 @@ class RequestTest extends TestCase
         $this->setExpectedException('InvalidArgumentException');
         $request = new Request(null, null, 'php://memory', [$name =>  $value]);
     }
+
+    public function hostHeaderKeys()
+    {
+        return [
+            'lowercase'            => ['host'],
+            'mixed-4'              => ['hosT'],
+            'mixed-3-4'            => ['hoST'],
+            'reverse-titlecase'    => ['hOST'],
+            'uppercase'            => ['HOST'],
+            'mixed-1-2-3'          => ['HOSt'],
+            'mixed-1-2'            => ['HOst'],
+            'titlecase'            => ['Host'],
+            'mixed-1-4'            => ['HosT'],
+            'mixed-1-2-4'          => ['HOsT'],
+            'mixed-1-3-4'          => ['HoST'],
+            'mixed-1-3'            => ['HoSt'],
+            'mixed-2-3'            => ['hOSt'],
+            'mixed-2-4'            => ['hOsT'],
+            'mixed-2'              => ['hOst'],
+            'mixed-3'              => ['hoSt'],
+        ];
+    }
+
+    /**
+     * @group 91
+     * @dataProvider hostHeaderKeys
+     */
+    public function testWithUriAndNoPreserveHostWillOverwriteHostHeaderRegardlessOfOriginalCase($hostKey)
+    {
+        $request = (new Request())
+            ->withHeader($hostKey, 'example.com');
+
+        $uri  = new Uri('http://example.org/foo/bar');
+        $new  = $request->withUri($uri);
+        $host = $new->getHeaderLine('host');
+        $this->assertEquals('example.org', $host);
+        $headers = $new->getHeaders();
+        $this->assertArrayHasKey('Host', $headers);
+        if ($hostKey !== 'Host') {
+            $this->assertArrayNotHasKey($hostKey, $headers);
+        }
+    }
 }


### PR DESCRIPTION
`RequestTrait::withUri` method [uses non-lowercased name for header "Host"](https://github.com/zendframework/zend-diactoros/blob/1.1.3/src/RequestTrait.php#L251). This can lead to duplicate "Host" header in request:

```php
$request = new \Zend\Diactoros\Request();
$request = $request->withHeader('host', 'foo.com');
// ...
$request = $request->withUri(new \Zend\Diactoros\Uri('http://bar.com'));

print_r($request->getHeaders());
```
Output:
```
Array
(
    [host] => Array
        (
            [0] => foo.com
        )
    [Host] => Array
        (
            [0] => bar.com
        )
)
```
And raw HTTP request will be something like this:
```
GET / HTTP/1.0
Host: foo.com
...
Host: bar.com
```
