### PR TITLE
Use unescaped slashes in encoded JSON by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#96](https://github.com/zendframework/zend-diactoros/pull/96) updates
   `withPort()` to allow `null` port values (indicating usage of default for
   the given scheme).
+- [#98](https://github.com/zendframework/zend-diactoros/pull/98) updates
+  the default JSON flags used by `JsonResponse` to include
+  `JSON_UNESCAPED_SLASHES`, which still conforms with RFC 4627, and is a more
+  sane default.
 
 ## 1.1.3 - 2015-08-10
 

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -25,6 +25,17 @@ class JsonResponse extends Response
     use InjectContentTypeTrait;
 
     /**
+     * Default flags for json_encode; value of:
+     *
+     * <code>
+     * JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+     * </code>
+     *
+     * @const int
+     */
+    const DEFAULT_JSON_FLAGS = 79;
+
+    /**
      * Create a JSON response with the given data.
      *
      * Default JSON encoding is performed with the following options, which
@@ -42,8 +53,12 @@ class JsonResponse extends Response
      * @param int $encodingOptions JSON encoding options to use.
      * @throws InvalidArgumentException if unable to encode the $data to JSON.
      */
-    public function __construct($data, $status = 200, array $headers = [], $encodingOptions = 79)
-    {
+    public function __construct(
+        $data,
+        $status = 200,
+        array $headers = [],
+        $encodingOptions = self::DEFAULT_JSON_FLAGS
+    ) {
         $body = new Stream('php://temp', 'wb+');
         $body->write($this->jsonEncode($data, $encodingOptions));
 

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -34,6 +34,7 @@ class JsonResponse extends Response
      * - JSON_HEX_APOS
      * - JSON_HEX_AMP
      * - JSON_HEX_QUOT
+     * - JSON_UNESCAPED_SLASHES
      *
      * @param mixed $data Data to convert to JSON.
      * @param int $status Integer status code for the response; 200 by default.
@@ -41,7 +42,7 @@ class JsonResponse extends Response
      * @param int $encodingOptions JSON encoding options to use.
      * @throws InvalidArgumentException if unable to encode the $data to JSON.
      */
-    public function __construct($data, $status = 200, array $headers = [], $encodingOptions = 15)
+    public function __construct($data, $status = 200, array $headers = [], $encodingOptions = 79)
     {
         $body = new Stream('php://temp', 'wb+');
         $body->write($this->jsonEncode($data, $encodingOptions));

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -98,4 +98,32 @@ class JsonResponseTest extends TestCase
         $this->setExpectedException('InvalidArgumentException', 'Unable to encode');
         new JsonResponse($data);
     }
+
+    public function valuesToJsonEncode()
+    {
+        return [
+            'uri'    => ['https://example.com/foo?bar=baz&baz=bat', 'uri'],
+            'html'   => ['<p class="test">content</p>', 'html'],
+            'string' => ["Don't quote!", 'string'],
+        ];
+    }
+
+    /**
+     * @dataProvider valuesToJsonEncode
+     */
+    public function testUsesSaneDefaultJsonEncodingFlags($value, $key)
+    {
+        $defaultFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES;
+
+        $response = new JsonResponse([$key => $value]);
+        $stream   = $response->getBody();
+        $contents = (string) $stream;
+
+        $expected = json_encode($value, $defaultFlags);
+        $this->assertContains(
+            $expected,
+            $contents,
+            sprintf('Did not encode %s properly; expected (%s), received (%s)', $key, $expected, $contents)
+        );
+    }
 }


### PR DESCRIPTION
Updated the default `$encodingOptions` to also include `JSON_UNESCAPED_SLASHES`, which is a sane default, and still complies with RFC 4627 (forward slash, or the solidus, does not need to be escaped).