### PR TITLE
Simplify status code

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -102,7 +102,7 @@ class Response implements ResponseInterface
     /**
      * @var int
      */
-    private $statusCode = 200;
+    private $statusCode;
 
     /**
      * @param string|resource|StreamInterface $stream Stream identifier and/or actual stream resource
@@ -120,12 +120,9 @@ class Response implements ResponseInterface
             );
         }
 
-        if (null !== $status) {
-            $this->validateStatus($status);
-        }
+        $this->setStatusCode($status);
 
-        $this->stream     = ($body instanceof StreamInterface) ? $body : new Stream($body, 'wb+');
-        $this->statusCode = $status ? (int) $status : 200;
+        $this->stream = ($body instanceof StreamInterface) ? $body : new Stream($body, 'wb+');
 
         list($this->headerNames, $headers) = $this->filterHeaders($headers);
         $this->assertHeaders($headers);
@@ -159,9 +156,8 @@ class Response implements ResponseInterface
      */
     public function withStatus($code, $reasonPhrase = '')
     {
-        $this->validateStatus($code);
         $new = clone $this;
-        $new->statusCode   = (int) $code;
+        $new->setStatusCode($code);
         $new->reasonPhrase = $reasonPhrase;
         return $new;
     }
@@ -172,7 +168,7 @@ class Response implements ResponseInterface
      * @param int|string $code
      * @throws InvalidArgumentException on an invalid status code.
      */
-    private function validateStatus($code)
+    private function setStatusCode($code)
     {
         if (! is_numeric($code)
             || is_float($code)
@@ -184,6 +180,7 @@ class Response implements ResponseInterface
                 (is_scalar($code) ? $code : gettype($code))
             ));
         }
+        $this->statusCode = $code;
     }
 
     /**

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -151,8 +151,16 @@ class ResponseTest extends TestCase
             'x-valid-string' => [ 'VALID' ],
             'x-valid-array' => [ 'VALID' ],
         ];
-        $response = new Response('php://memory', null, $headers);
+        $response = new Response('php://memory', 200, $headers);
         $this->assertEquals($expected, $response->getHeaders());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidStatusCodeInConstructor()
+    {
+        new Response('php://memory', null);
     }
 
     public function testReasonPhraseCanBeEmpty()

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -155,11 +155,10 @@ class ResponseTest extends TestCase
         $this->assertEquals($expected, $response->getHeaders());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidStatusCodeInConstructor()
     {
+        $this->setExpectedException('InvalidArgumentException');
+
         new Response('php://memory', null);
     }
 


### PR DESCRIPTION
I decided to simplify set status code. Why? Constructor's phpdocs says that it's expected `$status` variable as int, not null, only int. I know that make BC, however it should be done in my opinion