### PR TITLE
Header value not string

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -352,7 +352,7 @@ trait MessageTrait
 
             if (is_array($value)) {
                 array_walk($value, function ($item) {
-                    if (! is_array($item) && ! is_string($item) && ! is_numeric($item)) {
+                    if (! is_string($item) && ! is_numeric($item)) {
                         throw new InvalidArgumentException(sprintf(
                             'Invalid header value type; expected number, string, or array; received %s',
                             (is_object($item) ? get_class($item) : gettype($item))

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -337,7 +337,10 @@ trait MessageTrait
         $headerNames = $headers = [];
         foreach ($originalHeaders as $header => $value) {
             if (! is_string($header)) {
-                continue;
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid header name; expected non-empty string, received %s',
+                    gettype($header)
+                ));
             }
 
             if (! is_array($value) && ! is_string($value) && ! is_numeric($value)) {
@@ -345,6 +348,17 @@ trait MessageTrait
                     'Invalid header value type; expected number, string, or array; received %s',
                     (is_object($value) ? get_class($value) : gettype($value))
                 ));
+            }
+
+            if (is_array($value)) {
+                array_walk($value, function ($item) {
+                    if (! is_array($item) && ! is_string($item) && ! is_numeric($item)) {
+                        throw new InvalidArgumentException(sprintf(
+                            'Invalid header value type; expected number, string, or array; received %s',
+                            (is_object($item) ? get_class($item) : gettype($item))
+                        ));
+                    }
+                });
             }
 
             if (! is_array($value)) {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -341,7 +341,10 @@ trait MessageTrait
             }
 
             if (! is_array($value) && ! is_string($value) && ! is_numeric($value)) {
-                continue;
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid header value type; expected number, string, or array; received %s',
+                    (is_object($value) ? get_class($value) : gettype($value))
+                ));
             }
 
             if (! is_array($value)) {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -340,7 +340,7 @@ trait MessageTrait
                 continue;
             }
 
-            if (! is_array($value) && ! is_string($value)) {
+            if (! is_array($value) && ! is_string($value) && ! is_numeric($value)) {
                 continue;
             }
 

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -312,8 +312,17 @@ class MessageTraitTest extends TestCase
         ];
     }
 
+    public function invalidArrayHeaderValues()
+    {
+        yield 'array' => [['INVALID']];
+
+        foreach ($this->invalidHeaderValueTypes() as $type => $args) {
+            yield $type => $args;
+        }
+    }
+
     /**
-     * @dataProvider invalidHeaderValueTypes
+     * @dataProvider invalidArrayHeaderValues
      * @group 99
      */
     public function testFilterHeadersShouldRaiseExceptionForInvalidHeaderValuesInArrays($value)

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -324,7 +324,7 @@ class MessageTraitTest extends TestCase
             'X-Test-Array'  => [ $value ],
             'X-Test-Scalar' => $value,
         ];
-        $this->setExpectedException(InvalidArgumentException::class, 'header value type');
+        $this->setExpectedException('InvalidArgumentException', 'header value type');
         $filter->invoke($this->message, $headers);
     }
 }

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -316,12 +316,26 @@ class MessageTraitTest extends TestCase
      * @dataProvider invalidHeaderValueTypes
      * @group 99
      */
-    public function testFilterHeadersShouldRaiseExceptionForInvalidHeaderValues($value)
+    public function testFilterHeadersShouldRaiseExceptionForInvalidHeaderValuesInArrays($value)
     {
         $filter = new ReflectionMethod($this->message, 'filterHeaders');
         $filter->setAccessible(true);
         $headers = [
             'X-Test-Array'  => [ $value ],
+        ];
+        $this->setExpectedException('InvalidArgumentException', 'header value type');
+        $filter->invoke($this->message, $headers);
+    }
+
+    /**
+     * @dataProvider invalidHeaderValueTypes
+     * @group 99
+     */
+    public function testFilterHeadersShouldRaiseExceptionForInvalidHeaderScalarValues($value)
+    {
+        $filter = new ReflectionMethod($this->message, 'filterHeaders');
+        $filter->setAccessible(true);
+        $headers = [
             'X-Test-Scalar' => $value,
         ];
         $this->setExpectedException('InvalidArgumentException', 'header value type');

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -314,11 +314,9 @@ class MessageTraitTest extends TestCase
 
     public function invalidArrayHeaderValues()
     {
-        yield 'array' => [['INVALID']];
-
-        foreach ($this->invalidHeaderValueTypes() as $type => $args) {
-            yield $type => $args;
-        }
+        $values = $this->invalidHeaderValueTypes();
+        $values['array'] = [['INVALID']];
+        return $values;
     }
 
     /**

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Diactoros;
 
+use InvalidArgumentException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Stream;
@@ -192,24 +193,25 @@ class RequestTest extends TestCase
         new Request(null, null, $body);
     }
 
-    public function testConstructorIgonoresInvalidHeaders()
+    public function invalidHeaderTypes()
     {
-        $headers = [
-            [ 'INVALID' ],
-            'x-invalid-null' => null,
-            'x-invalid-true' => true,
-            'x-invalid-false' => false,
-            'x-invalid-int' => 1,
-            'x-invalid-object' => (object) ['INVALID'],
-            'x-valid-string' => 'VALID',
-            'x-valid-array' => [ 'VALID' ],
+        return [
+            'indexed-array' => [[['INVALID']], 'header name'],
+            'null' => [['x-invalid-null' => null]],
+            'true' => [['x-invalid-true' => true]],
+            'false' => [['x-invalid-false' => false]],
+            'object' => [['x-invalid-object' => (object) ['INVALID']]],
         ];
-        $expected = [
-            'x-valid-string' => [ 'VALID' ],
-            'x-valid-array' => [ 'VALID' ],
-        ];
-        $request = new Request(null, null, 'php://memory', $headers);
-        $this->assertEquals($expected, $request->getHeaders());
+    }
+
+    /**
+     * @dataProvider invalidHeaderTypes
+     * @group 99
+     */
+    public function testConstructorRaisesExceptionForInvalidHeaders($headers, $contains = 'header value type')
+    {
+        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        new Request(null, null, 'php://memory', $headers);
     }
 
     public function testRequestTargetIsSlashWhenNoUriPresent()

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -210,7 +210,7 @@ class RequestTest extends TestCase
      */
     public function testConstructorRaisesExceptionForInvalidHeaders($headers, $contains = 'header value type')
     {
-        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        $this->setExpectedException('InvalidArgumentException', $contains);
         new Request(null, null, 'php://memory', $headers);
     }
 

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Diactoros;
 
+use InvalidArgumentException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
@@ -135,24 +136,26 @@ class ResponseTest extends TestCase
         new Response($body);
     }
 
-    public function testConstructorIgonoresInvalidHeaders()
+
+    public function invalidHeaderTypes()
     {
-        $headers = [
-            [ 'INVALID' ],
-            'x-invalid-null' => null,
-            'x-invalid-true' => true,
-            'x-invalid-false' => false,
-            'x-invalid-int' => 1,
-            'x-invalid-object' => (object) ['INVALID'],
-            'x-valid-string' => 'VALID',
-            'x-valid-array' => [ 'VALID' ],
+        return [
+            'indexed-array' => [[['INVALID']], 'header name'],
+            'null' => [['x-invalid-null' => null]],
+            'true' => [['x-invalid-true' => true]],
+            'false' => [['x-invalid-false' => false]],
+            'object' => [['x-invalid-object' => (object) ['INVALID']]],
         ];
-        $expected = [
-            'x-valid-string' => [ 'VALID' ],
-            'x-valid-array' => [ 'VALID' ],
-        ];
-        $response = new Response('php://memory', 200, $headers);
-        $this->assertEquals($expected, $response->getHeaders());
+    }
+
+    /**
+     * @dataProvider invalidHeaderTypes
+     * @group 99
+     */
+    public function testConstructorRaisesExceptionForInvalidHeaders($headers, $contains = 'header value type')
+    {
+        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        new Response('php://memory', 200, $headers);
     }
 
     public function testInvalidStatusCodeInConstructor()

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -154,7 +154,7 @@ class ResponseTest extends TestCase
      */
     public function testConstructorRaisesExceptionForInvalidHeaders($headers, $contains = 'header value type')
     {
-        $this->setExpectedException(InvalidArgumentException::class, $contains);
+        $this->setExpectedException('InvalidArgumentException', $contains);
         new Response('php://memory', 200, $headers);
     }
 


### PR DESCRIPTION
I have tried to create a request and I added header:
```php
[
  'X-User-Id': 123,
]
```
After this my request doesn't have `X-User-Id` header. After debug I have found this https://github.com/zendframework/zend-diactoros/blob/1037ed1cb4e240eba665597e4c373e57fb9ea24c/src/MessageTrait.php#L341

Should we throw exception instead of continue code execution?