### PR TITLE
Added HTTP 451 status code

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -81,6 +81,7 @@ class Response implements ResponseInterface
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',
+        451 => 'Unavailable For Legal Reasons',
         // SERVER ERROR
         500 => 'Internal Server Error',
         501 => 'Not Implemented',


### PR DESCRIPTION
https://datatracker.ietf.org/doc/draft-ietf-httpbis-legally-restricted-status/?include_text=1

The HTTP 451 status code was approved by the ISG a few days ago on the 18th December '15.