### PR TITLE
Include COOKIE header in request headers

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -198,11 +198,6 @@ abstract class ServerRequestFactory
     {
         $headers = [];
         foreach ($server as $key => $value) {
-            if (strpos($key, 'HTTP_COOKIE') === 0) {
-                // Cookies are handled using the $_COOKIE superglobal
-                continue;
-            }
-
             if ($value && strpos($key, 'HTTP_') === 0) {
                 $name = strtr(substr($key, 5), '_', ' ');
                 $name = strtr(ucwords(strtolower($name)), ' ', '-');

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -69,6 +69,7 @@ class ServerRequestFactoryTest extends TestCase
         ];
 
         $expected = [
+            'cookie' => 'COOKIE',
             'authorization' => 'token',
             'content-type' => 'application/json',
             'accept' => 'application/json',


### PR DESCRIPTION
> Cookies *are* available in $_COOKIE, and hence also the cookie params, but there may be times you want raw access to the header. There's no good reason to omit the header from the request.
> – @weierophinney

I've been working with [dflydev/fig-cookies](https://github.com/dflydev/dflydev-fig-cookies) which relies entirely on being able to read and parse the cookie header from `RequestInterface` instances. Much to my surprise, request instances didn't have a cookie header even though I was sending cookies.

After a quick chat with @weierophinney he was able to verify that cookie headers were indeed intentionally being excluded as a header for `ServerRequestInterface` instances that were created using the `ServerRequestFactory`.

This PR allows cookie headers that are sent to be included in the request instances created by `ServerRequestFactory`.