### PR TITLE
Correction of regular expression for HTTP 2.0

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -465,7 +465,7 @@ abstract class ServerRequestFactory
             return '1.1';
         }
 
-        if (! preg_match('#^(HTTP/)?(?P<version>[1-9]\d*\.\d)$#', $server['SERVER_PROTOCOL'], $matches)) {
+        if (! preg_match('#^(HTTP/)?(?P<version>[1-9]\d*(?:\.\d)?)$#', $server['SERVER_PROTOCOL'], $matches)) {
             throw new UnexpectedValueException(sprintf(
                 'Unrecognized protocol version (%s)',
                 $server['SERVER_PROTOCOL']


### PR DESCRIPTION
The "SERVER_PROTOCOL" value returned by Apache is "HTTP/2" (and not "HTTP/2.0"). I adjusted the regular expression to match it.