### PR TITLE
Fix minor typo in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ pull your work into the master repository. We recommend using
 3. Clone the canonical repository locally and enter it.
 
    ```console
-   $ git clone git://github.com:zendframework/zend-diactoros.git
+   $ git clone git://github.com/zendframework/zend-diactoros.git
    $ cd zend-diactoros
    ```
 


### PR DESCRIPTION
I found a minor typo in the contributing guide wrt the diactoros repository. 