### PR TITLE
Remove unnecessary test in URI constructor

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -99,10 +99,8 @@ class Uri implements UriInterface
                 (is_object($uri) ? get_class($uri) : gettype($uri))
             ));
         }
-
-        if (! empty($uri)) {
-            $this->parseUri($uri);
-        }
+        
+        $this->parseUri($uri);
     }
 
     /**


### PR DESCRIPTION
In 99,9% we should create object using constructor and parse uri argument

- lighter constructor
- lower complexity