### PR TITLE
Verbose exception message from header validators

### DIFF
--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -129,7 +129,7 @@ final class HeaderSecurity
     public static function assertValid($value)
     {
         if (! self::isValid($value)) {
-            throw new InvalidArgumentException('Invalid header value');
+            throw new InvalidArgumentException("'$value' is not valid header value");
         }
     }
 
@@ -143,7 +143,7 @@ final class HeaderSecurity
     public static function assertValidName($name)
     {
         if (! preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/', $name)) {
-            throw new InvalidArgumentException('Invalid header name');
+            throw new InvalidArgumentException("'$name' is not valid header name");
         }
     }
 }


### PR DESCRIPTION
With current version of Diactoros I often see exceptions like "Invalid header value". It doesn't show which header is not valid, making it difficult to see what's the problem. 
With this PR server logs will clearly show which header caused exception.