### PR TITLE
Add withServerParams method to ServerRequest

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -107,6 +107,13 @@ class ServerRequest implements ServerRequestInterface
         return $this->serverParams;
     }
 
+    public function withServerParams(array $serverParams)
+    {
+        $new = clone $this;
+        $new->serverParams = $serverParams;
+        return $new;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -32,6 +32,14 @@ class ServerRequestTest extends TestCase
         $this->assertEmpty($this->request->getServerParams());
     }
 
+    public function testServerParamsMutatorReturnsCloneWithChanges()
+    {
+        $value = ['foo' => 'bar'];
+        $request = $this->request->withServerParams($value);
+        $this->assertNotSame($this->request, $request);
+        $this->assertEquals($value, $request->getServerParams());
+    }
+
     public function testQueryParamsAreEmptyByDefault()
     {
         $this->assertEmpty($this->request->getQueryParams());


### PR DESCRIPTION
`ServerRequest` contains methods like `withCookieParams` or `withQueryParams`, but it does not provide any way of changing server params. `withServerParams` is not even present in PSR-7 interface. Was it a deliberate choice (I can't find any discussion on this subject)? 

I found this method missing when working on a middleware that normalizes how information about HTTPS is passed into next layers. Usually you check it with `$_SERVER['HTTPS']`, but if your webserver is behind proxy, you may have to check other headers. I would like to write middleware like this one:

```php
class HttpsMiddleware
{
    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
    {
        $params = $request->getServerParams();
        if ((isset($params['HTTP_X_FORWARDED_PROTO']) && $params['HTTP_X_FORWARDED_PROTO'] == 'https')
            || (isset($params['HTTP_CF_VISITOR']) && $params['HTTP_CF_VISITOR'] == '{"scheme":"https"}')
        ) {
            $params['HTTPS'] = 'on';

            $request = $request->withServerParams($params);
        }

        return $next($request, $response);
    }
}
```

This PR adds `withServerParams` method to `ServerRequest` implementation (in obviously not-SOLID way), but at least this problem is flagged somewhere.