### PR TITLE
Removed php7 from allowed_failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ matrix:
       env:
         - EXECUTE_COVERAGE=true
     - php: 7
-    - php: hhvm 
-  allow_failures:
-    - php: 7
+    - php: hhvm
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"


### PR DESCRIPTION
Since PHP 7 was released, i think it shouldn't be allowed to fail on Travis.