### PR TITLE
Relative stream out of bounds protection

### DIFF
--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -10,6 +10,7 @@
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 /**
  * Class RelativeStream
@@ -131,6 +132,9 @@ final class RelativeStream implements StreamInterface
      */
     public function write($string)
     {
+        if ($this->tell() < 0) {
+            throw new RuntimeException('Invalid pointer position');
+        }
         return $this->decoratedStream->write($string);
     }
 
@@ -147,6 +151,9 @@ final class RelativeStream implements StreamInterface
      */
     public function read($length)
     {
+        if ($this->tell() < 0) {
+            throw new RuntimeException('Invalid pointer position');
+        }
         return $this->decoratedStream->read($length);
     }
 
@@ -155,6 +162,9 @@ final class RelativeStream implements StreamInterface
      */
     public function getContents()
     {
+        if ($this->tell() < 0) {
+            throw new RuntimeException('Invalid pointer position');
+        }
         return $this->decoratedStream->getContents();
     }
 

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -21,6 +21,7 @@ class RelativeStreamTest extends TestCase
     public function testToString()
     {
         $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->willReturn(100);
         $decorated->seek(100, SEEK_SET)->shouldBeCalled();
         $decorated->getContents()->shouldBeCalled()->willReturn('foobarbaz');
 
@@ -112,6 +113,7 @@ class RelativeStreamTest extends TestCase
     public function testWrite()
     {
         $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->willReturn(100);
         $decorated->write("foobaz")->shouldBeCalled()->willReturn(6);
         $stream = new RelativeStream($decorated->reveal(), 100);
         $ret = $stream->write("foobaz");
@@ -121,6 +123,7 @@ class RelativeStreamTest extends TestCase
     public function testRead()
     {
         $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->willReturn(100);
         $decorated->read(3)->shouldBeCalled()->willReturn("foo");
         $stream = new RelativeStream($decorated->reveal(), 100);
         $ret = $stream->read(3);
@@ -130,6 +133,7 @@ class RelativeStreamTest extends TestCase
     public function testGetContents()
     {
         $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->willReturn(100);
         $decorated->getContents()->shouldBeCalled()->willReturn("foo");
         $stream = new RelativeStream($decorated->reveal(), 100);
         $ret = $stream->getContents();
@@ -143,5 +147,35 @@ class RelativeStreamTest extends TestCase
         $stream = new RelativeStream($decorated->reveal(), 100);
         $ret = $stream->getMetadata("bar");
         $this->assertEquals("foo", $ret);
+    }
+
+    public function testWriteRaisesExceptionWhenPointerIsBehindOffset()
+    {
+        $this->setExpectedException('RuntimeException', 'Invalid pointer position');
+        $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->shouldBeCalled()->willReturn(0);
+        $decorated->write("foobaz")->shouldNotBeCalled();
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $stream->write("foobaz");
+    }
+
+    public function testReadRaisesExceptionWhenPointerIsBehindOffset()
+    {
+        $this->setExpectedException('RuntimeException', 'Invalid pointer position');
+        $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->shouldBeCalled()->willReturn(0);
+        $decorated->read(3)->shouldNotBeCalled();
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $stream->read(3);
+    }
+
+    public function testGetContentsRaisesExceptionWhenPointerIsBehindOffset()
+    {
+        $this->setExpectedException('RuntimeException', 'Invalid pointer position');
+        $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->tell()->shouldBeCalled()->willReturn(0);
+        $decorated->getContents()->shouldNotBeCalled();
+        $stream = new RelativeStream($decorated->reveal(), 100);
+        $stream->getContents();
     }
 }


### PR DESCRIPTION
Added safeguard to prevent accidental access to part of decorated stream before offset.

I considered seeking to 0 instead but that will only mask problem, hard fail is preferable.

Problem is bigger tho, since relative stream is shared by definition. See #147 