### PR TITLE
Fix invalid default method

### DIFF
--- a/src/Request/Serializer.php
+++ b/src/Request/Serializer.php
@@ -77,9 +77,6 @@ final class Serializer extends AbstractSerializer
     public static function toString(RequestInterface $request)
     {
         $httpMethod = $request->getMethod();
-        if (empty($httpMethod)) {
-            throw new UnexpectedValueException('Object can not be serialized because HTTP method is empty');
-        }
         $headers = self::serializeHeaders($request->getHeaders());
         $body    = (string) $request->getBody();
         $format  = '%s %s HTTP/%s%s%s';

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -33,7 +33,7 @@ trait RequestTrait
     /**
      * @var string
      */
-    private $method = '';
+    private $method = 'GET';
 
     /**
      * The request-target, if it has been provided or calculated.
@@ -60,9 +60,10 @@ trait RequestTrait
      */
     private function initialize($uri = null, $method = null, $body = 'php://memory', array $headers = [])
     {
-        $this->validateMethod($method);
+        if ($method !== null) {
+            $this->setMethod($method);
+        }
 
-        $this->method = $method ?: '';
         $this->uri    = $this->createUri($uri);
         $this->stream = $this->getStream($body, 'wb+');
 
@@ -199,9 +200,8 @@ trait RequestTrait
      */
     public function withMethod($method)
     {
-        $this->validateMethod($method);
         $new = clone $this;
-        $new->method = $method;
+        $new->setMethod($method);
         return $new;
     }
 
@@ -279,17 +279,13 @@ trait RequestTrait
     }
 
     /**
-     * Validate the HTTP method
+     * Set and validate the HTTP method
      *
-     * @param null|string $method
+     * @param string $method
      * @throws InvalidArgumentException on invalid HTTP method.
      */
-    private function validateMethod($method)
+    private function setMethod($method)
     {
-        if (null === $method) {
-            return;
-        }
-
         if (! is_string($method)) {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported HTTP method; must be a string, received %s',
@@ -303,6 +299,7 @@ trait RequestTrait
                 $method
             ));
         }
+        $this->method = $method;
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -224,42 +224,6 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Proxy to receive the request method.
-     *
-     * This overrides the parent functionality to ensure the method is never
-     * empty; if no method is present, it returns 'GET'.
-     *
-     * @return string
-     */
-    public function getMethod()
-    {
-        if (empty($this->method)) {
-            return 'GET';
-        }
-        return $this->method;
-    }
-
-    /**
-     * Set the request method.
-     *
-     * Unlike the regular Request implementation, the server-side
-     * normalizes the method to uppercase to ensure consistency
-     * and make checking the method simpler.
-     *
-     * This methods returns a new instance.
-     *
-     * @param string $method
-     * @return self
-     */
-    public function withMethod($method)
-    {
-        $this->validateMethod($method);
-        $new = clone $this;
-        $new->method = $method;
-        return $new;
-    }
-
-    /**
      * Recursively validate the structure in an uploaded files array.
      *
      * @param array $uploadedFiles

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -327,14 +327,4 @@ class SerializerTest extends TestCase
         $stream = Serializer::fromStream($stream);
         $this->assertInstanceOf('Zend\Diactoros\RelativeStream', $stream->getBody());
     }
-
-    /**
-     * @expectedException UnexpectedValueException
-     */
-    public function testToStringRaisesExceptionOnEmptyMethod()
-    {
-        $request = (new Request())
-            ->withUri(new Uri('http://example.com/foo/bar?baz=bat'));
-        $message = Serializer::toString($request);
-    }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -27,16 +27,34 @@ class RequestTest extends TestCase
         $this->request = new Request();
     }
 
-    public function testMethodIsEmptyByDefault()
+    public function testMethodIsGetByDefault()
     {
-        $this->assertSame('', $this->request->getMethod());
+        $this->assertSame('GET', $this->request->getMethod());
     }
 
     public function testMethodMutatorReturnsCloneWithChangedMethod()
     {
-        $request = $this->request->withMethod('GET');
+        $request = $this->request->withMethod('POST');
         $this->assertNotSame($this->request, $request);
-        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('POST', $request->getMethod());
+    }
+
+    public function invalidMethod()
+    {
+        return [
+            [null],
+            [''],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidMethod
+     */
+    public function testWithInvalidMethod($method)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        $this->request->withMethod($method);
     }
 
     public function testReturnsUnpopulatedUriByDefault()


### PR DESCRIPTION
Currently, when method is not provided it's set as empty string. It's invalid state, because it's not possible to set new method (using `withMethod`) as empty string. It's also other possible invalid state - we can set new method as `null`, which is not compatible with `RequestInterface`.