### PR TITLE
Added support for utf8 path

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -36,7 +36,7 @@ class Uri implements UriInterface
      *
      * @const string
      */
-    const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
+    const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~\pL';
 
     /**
      * @var int[] Array indexed by valid scheme names to their corresponding ports.
@@ -553,7 +553,7 @@ class Uri implements UriInterface
     private function filterPath($path)
     {
         $path = preg_replace_callback(
-            '/(?:[^' . self::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/',
+            '/(?:[^' . self::CHAR_UNRESERVED . ':@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/u',
             [$this, 'urlEncodeChar'],
             $path
         );

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -568,4 +568,24 @@ class UriTest extends TestCase
 
         $this->assertEquals('ουτοπία.δπθ.gr', $uri->getHost());
     }
+
+
+    /**
+     * @dataProvider utf8PathsDataProvider
+     */
+    public function testUtf8Path($url, $result)
+    {
+        $uri = new Uri($url);
+
+        $this->assertEquals($result, $uri->getPath());
+    }
+
+
+    public function utf8PathsDataProvider()
+    {
+        return [
+            ['http://example.com/тестовый_путь/', '/тестовый_путь/'],
+            ['http://example.com/ουτοπία/', '/ουτοπία/']
+        ];
+    }
 }


### PR DESCRIPTION
Currently, we can't work with non-latin letters in path. For example: http://example.com/тестовый_путь/ or http://example.com/flüg/. I resolve this problem by adding in `CHAR_UNRESERVED ` constant `\pL` for support utf-8 letters.