### PR TITLE
Fix reponse serialization if response body is empty.

### DIFF
--- a/src/Response/Serializer.php
+++ b/src/Response/Serializer.php
@@ -73,9 +73,8 @@ final class Serializer extends AbstractSerializer
         if (! empty($headers)) {
             $headers = "\r\n" . $headers;
         }
-        if (! empty($body)) {
-            $headers .= "\r\n\r\n";
-        }
+
+        $headers .= "\r\n\r\n";
 
         return sprintf(
             $format,

--- a/test/Response/SerializerTest.php
+++ b/test/Response/SerializerTest.php
@@ -31,6 +31,19 @@ class SerializerTest extends TestCase
         );
     }
 
+    public function testSerializesResponseWithoutBodyCorrectly()
+    {
+        $response = (new Response())
+            ->withStatus(200)
+            ->withAddedHeader('Content-Type', 'text/plain');
+
+        $message = Serializer::toString($response);
+        $this->assertEquals(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n",
+            $message
+        );
+    }
+
     public function testSerializesMultipleHeadersCorrectly()
     {
         $response = (new Response())


### PR DESCRIPTION
The newline after the headers was missing if the response body was empty.