### PR TITLE
marshall nicely formatted header names

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -199,7 +199,6 @@ abstract class ServerRequestFactory
             if ($value && strpos($key, 'HTTP_') === 0) {
                 $name = strtr(substr($key, 5), '_', ' ');
                 $name = strtr(ucwords(strtolower($name)), ' ', '-');
-                $name = strtolower($name);
 
                 $headers[$name] = $value;
                 continue;
@@ -208,7 +207,7 @@ abstract class ServerRequestFactory
             if ($value && strpos($key, 'CONTENT_') === 0) {
                 $name = substr($key, 8); // Content-
                 $name = 'Content-' . (($name == 'MD5') ? $name : ucfirst(strtolower($name)));
-                $name = strtolower($name);
+
                 $headers[$name] = $value;
                 continue;
             }


### PR DESCRIPTION
otherwise we could just rewrite the method simply as:
```php
    public static function marshalHeaders(array $server)
    {
        $headers = [];
        foreach ($server as $key => $value) {
            if ($value && strpos($key, 'HTTP_') === 0) {
                $name = strtr(strtolower(substr($key, 5)), '_', '- ');
                $headers[$name] = $value;
                continue;
            }

            if ($value && strpos($key, 'CONTENT_') === 0) {
                $name = 'content-' . strtolower(substr($key, 8));
                $headers[$name] = $value;
                continue;
            }
        }

        return $headers;
    }
```

without ucwords/ucfirst (redundant because overwritten by last strtolower) calls

header array created via marshallHeader are filtered via `MessageTrait::filterHeaders(array $originalHeaders)`. Original/well-formatted headers are kept in the $header property, lowercased header names are used as keys of $headerNames.