### PR TITLE
remove overwritten function calls

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -197,7 +197,7 @@ abstract class ServerRequestFactory
         $headers = [];
         foreach ($server as $key => $value) {
             if ($value && strpos($key, 'HTTP_') === 0) {
-                $name = strtr(strtolower(substr($key, 5)), '_', '- ');
+                $name = strtr(strtolower(substr($key, 5)), '_', '-');
                 $headers[$name] = $value;
                 continue;
             }

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -197,18 +197,13 @@ abstract class ServerRequestFactory
         $headers = [];
         foreach ($server as $key => $value) {
             if ($value && strpos($key, 'HTTP_') === 0) {
-                $name = strtr(substr($key, 5), '_', ' ');
-                $name = strtr(ucwords(strtolower($name)), ' ', '-');
-                $name = strtolower($name);
-
+                $name = strtr(strtolower(substr($key, 5)), '_', '- ');
                 $headers[$name] = $value;
                 continue;
             }
 
             if ($value && strpos($key, 'CONTENT_') === 0) {
-                $name = substr($key, 8); // Content-
-                $name = 'Content-' . (($name == 'MD5') ? $name : ucfirst(strtolower($name)));
-                $name = strtolower($name);
+                $name = 'content-' . strtolower(substr($key, 8));
                 $headers[$name] = $value;
                 continue;
             }


### PR DESCRIPTION
at the end HTTP_ and CONTENT_ header names from $_SERVER and mocked request are normalized to lowercase, so nice formatting function calls (ucwords/ucfirst) are redundant.