### PR TITLE
Fix incompatibilities between Unseekable streams and SapiStreamEmitter

### DIFF
--- a/src/Response/SapiStreamEmitter.php
+++ b/src/Response/SapiStreamEmitter.php
@@ -76,10 +76,17 @@ class SapiStreamEmitter implements EmitterInterface
      */
     private function emitBodyRange(array $range, ResponseInterface $response, $maxBufferLength)
     {
-        list($unit, $first, $last, $lenght) = $range;
+        list($unit, $first, $last, $length) = $range;
 
         ++$last; //zero-based position
         $body = $response->getBody();
+
+        if (!$body->isSeekable()) {
+            $contents = $body->getContents();
+            echo substr($contents, $first, $last - $first);
+            return;
+        }
+
         $body->seek($first);
         $pos = $first;
 

--- a/src/Response/SapiStreamEmitter.php
+++ b/src/Response/SapiStreamEmitter.php
@@ -56,10 +56,14 @@ class SapiStreamEmitter implements EmitterInterface
     private function emitBody(ResponseInterface $response, $maxBufferLength)
     {
         $body = $response->getBody();
-        $body->rewind();
+        if ($body->isSeekable()) {
+            $body->rewind();
 
-        while (! $body->eof()) {
-            echo $body->read($maxBufferLength);
+            while (! $body->eof()) {
+                echo $body->read($maxBufferLength);
+            }
+        } else {
+            echo $body;
         }
     }
 

--- a/test/Response/SapiStreamEmitterTest.php
+++ b/test/Response/SapiStreamEmitterTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Diactoros\Response;
 use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Zend\Diactoros\CallbackStream;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\SapiStreamEmitter;
 use ZendTest\Diactoros\TestAsset\HeaderStack;
@@ -22,6 +23,19 @@ class SapiStreamEmitterTest extends SapiEmitterTest
     {
         HeaderStack::reset();
         $this->emitter = new SapiStreamEmitter();
+    }
+
+    public function testEmitCallbackStreamResponse()
+    {
+        $stream = new CallbackStream(function () {
+            return 'it works';
+        });
+        $response = (new Response())
+            ->withStatus(200)
+            ->withBody($stream);
+        ob_start();
+        $this->emitter->emit($response);
+        $this->assertEquals('it works', ob_get_clean());
     }
 
     public function testDoesNotInjectContentLengthHeaderIfStreamSizeIsUnknown()

--- a/test/Response/SapiStreamEmitterTest.php
+++ b/test/Response/SapiStreamEmitterTest.php
@@ -80,4 +80,18 @@ class SapiStreamEmitterTest extends SapiEmitterTest
         $this->emitter->emit($response);
         $this->assertEquals($expected, ob_get_clean());
     }
+
+    public function testContentRangeUnseekableBody()
+    {
+        $body = new CallbackStream(function () {
+            return 'Hello world';
+        });
+        $response = (new Response())
+            ->withBody($body)
+            ->withHeader('Content-Range', 'bytes 3-6/*');
+
+        ob_start();
+        $this->emitter->emit($response);
+        $this->assertEquals('lo w', ob_get_clean());
+    }
 }


### PR DESCRIPTION
Make `SapiStreamEmitter` work with streams that don't support seek operations. This allows `CallbackStream` responses to be combined with `SapiStreamEmitter`.

Refs #199