### PR TITLE
phpunit version update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "psr/http-message": "~1.0"
   },
   "require-dev": {
-    "phpunit/PHPUnit": "~4.6",
+    "phpunit/phpunit": "^5.5",
     "squizlabs/php_codesniffer": "^2.3.1"
   },
   "provide": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "psr/http-message": "~1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5",
+    "phpunit/phpunit": "^4.6 || ^5.5",
     "squizlabs/php_codesniffer": "^2.3.1"
   },
   "provide": {

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -24,7 +24,7 @@ class MessageTraitTest extends TestCase
 
     public function setUp()
     {
-        $this->message = new Request(null, null, $this->getMock('Psr\Http\Message\StreamInterface'));
+        $this->message = new Request(null, null, $this->createMock('Psr\Http\Message\StreamInterface'));
     }
 
     public function testProtocolHasAcceptableDefault()
@@ -69,14 +69,14 @@ class MessageTraitTest extends TestCase
 
     public function testUsesStreamProvidedInConstructorAsBody()
     {
-        $stream  = $this->getMock('Psr\Http\Message\StreamInterface');
+        $stream  = $this->createMock('Psr\Http\Message\StreamInterface');
         $message = new Request(null, null, $stream);
         $this->assertSame($stream, $message->getBody());
     }
 
     public function testBodyMutatorReturnsCloneWithChanges()
     {
-        $stream  = $this->getMock('Psr\Http\Message\StreamInterface');
+        $stream  = $this->createMock('Psr\Http\Message\StreamInterface');
         $message = $this->message->withBody($stream);
         $this->assertNotSame($this->message, $message);
         $this->assertSame($stream, $message->getBody());

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -24,7 +24,7 @@ class MessageTraitTest extends TestCase
 
     public function setUp()
     {
-        $this->message = new Request(null, null, $this->createMock('Psr\Http\Message\StreamInterface'));
+        $this->message = new Request(null, null, $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock());
     }
 
     public function testProtocolHasAcceptableDefault()
@@ -69,14 +69,14 @@ class MessageTraitTest extends TestCase
 
     public function testUsesStreamProvidedInConstructorAsBody()
     {
-        $stream  = $this->createMock('Psr\Http\Message\StreamInterface');
+        $stream  = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
         $message = new Request(null, null, $stream);
         $this->assertSame($stream, $message->getBody());
     }
 
     public function testBodyMutatorReturnsCloneWithChanges()
     {
-        $stream  = $this->createMock('Psr\Http\Message\StreamInterface');
+        $stream  = $this->getMockBuilder('Psr\Http\Message\StreamInterface')->getMock();
         $message = $this->message->withBody($stream);
         $this->assertNotSame($this->message, $message);
         $this->assertSame($stream, $message->getBody());

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -40,8 +40,8 @@ class ServerTest extends TestCase
         $this->callback   = function ($req, $res, $done) {
             //  Intentionally empty
         };
-        $this->request = $this->getMock('Psr\Http\Message\ServerRequestInterface');
-        $this->response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $this->request = $this->createMock('Psr\Http\Message\ServerRequestInterface');
+        $this->response = $this->createMock('Psr\Http\Message\ResponseInterface');
     }
 
     public function tearDown()
@@ -93,7 +93,7 @@ class ServerTest extends TestCase
             $this->request,
             $this->response
         );
-        $emmiter = $this->getMock('Zend\Diactoros\Response\EmitterInterface');
+        $emmiter = $this->createMock('Zend\Diactoros\Response\EmitterInterface');
         $emmiter->expects($this->once())->method('emit');
 
         $server->setEmitter($emmiter);

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -40,8 +40,8 @@ class ServerTest extends TestCase
         $this->callback   = function ($req, $res, $done) {
             //  Intentionally empty
         };
-        $this->request = $this->createMock('Psr\Http\Message\ServerRequestInterface');
-        $this->response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $this->request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $this->response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
     }
 
     public function tearDown()
@@ -93,7 +93,7 @@ class ServerTest extends TestCase
             $this->request,
             $this->response
         );
-        $emmiter = $this->createMock('Zend\Diactoros\Response\EmitterInterface');
+        $emmiter = $this->getMockBuilder('Zend\Diactoros\Response\EmitterInterface')->getMock();
         $emmiter->expects($this->once())->method('emit');
 
         $server->setEmitter($emmiter);


### PR DESCRIPTION
I update PHPUnit versiyon to ^5.5. But there is some issue on `UriTest.php` like this: 

```
PHPUnit 5.5.4 by Sebastian Bergmann and contributors.

...............................................................  63 / 807 (  7%)
............................................................... 126 / 807 ( 15%)
............................................................... 189 / 807 ( 23%)
............................................................... 252 / 807 ( 31%)
............................................................... 315 / 807 ( 39%)
............................................................... 378 / 807 ( 46%)
............................................................... 441 / 807 ( 54%)
............................................................... 504 / 807 ( 62%)
............................................................... 567 / 807 ( 70%)
............................................................... 630 / 807 ( 78%)
............................................................... 693 / 807 ( 85%)
............................................................... 756 / 807 ( 93%)
................................................FFF             807 / 807 (100%)

Time: 7.38 seconds, Memory: 21.75MB

There were 3 failures:

1) ZendTest\Diactoros\UriTest::testUtf8Uri
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'ουτοπία.δπθ.gr'
+'ο�_�_ο�_ία.δ�_θ.gr'

/Volumes/......../zend-diactoros/test/UriTest.php:569

2) ZendTest\Diactoros\UriTest::testUtf8Path with data set #0 ('http://example.com/тестовый_путь/', '/тестовый_путь/')
Failed asserting that null matches expected '/тестовый_путь/'.

/Volumes/......../zend-diactoros/test/UriTest.php:580

3) ZendTest\Diactoros\UriTest::testUtf8Path with data set #1 ('http://example.com/ουτοπία/', '/ουτοπία/')
Failed asserting that null matches expected '/ουτοπία/'.

/Volumes/......../zend-diactoros/test/UriTest.php:580

FAILURES!
Tests: 807, Assertions: 1367, Failures: 3.
```

I guess, they are not about PHPUnit version.  ping @weierophinney 