### PR TITLE
Fix undefined class UriInterface in PHPDoc

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -11,6 +11,7 @@ namespace Zend\Diactoros;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * HTTP Request encapsulation


### PR DESCRIPTION
![undefined-class-example](https://cloud.githubusercontent.com/assets/2891564/18517618/3781e692-7a9d-11e6-8046-695945de7081.png)
