### PR TITLE
Add missing HTTP status codes/messages

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -44,6 +44,7 @@ class Response implements ResponseInterface
         206 => 'Partial Content',
         207 => 'Multi-status',
         208 => 'Already Reported',
+        226 => 'IM used',
         // REDIRECTION CODES
         300 => 'Multiple Choices',
         301 => 'Moved Permanently',
@@ -53,6 +54,7 @@ class Response implements ResponseInterface
         305 => 'Use Proxy',
         306 => 'Switch Proxy', // Deprecated
         307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
         // CLIENT ERROR
         400 => 'Bad Request',
         401 => 'Unauthorized',

--- a/src/Response.php
+++ b/src/Response.php
@@ -81,8 +81,10 @@ class Response implements ResponseInterface
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',
+        444 => 'Connection Closed Without Response',
         451 => 'Unavailable For Legal Reasons',
         // SERVER ERROR
+        499 => 'Client Closed Request',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',
@@ -92,7 +94,9 @@ class Response implements ResponseInterface
         506 => 'Variant Also Negotiates',
         507 => 'Insufficient Storage',
         508 => 'Loop Detected',
+        510 => 'Not Extended',
         511 => 'Network Authentication Required',
+        599 => 'Network Connect Timeout Error',
     ];
 
     /**


### PR DESCRIPTION
At https://github.com/cakephp/cakephp/issues/9516, we were discussing missing status codes in CakePHP's and Zend's libraries.

This brings both (almost) [in sync](https://github.com/cakephp/cakephp/pull/9523) by adding missing status codes & messages.

Used https://httpstatuses.com/ as reference.
