### PR TITLE
Add support for UTF-8 query string

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -645,7 +645,7 @@ class Uri implements UriInterface
     private function filterQueryOrFragment($value)
     {
         return preg_replace_callback(
-            '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]+|%(?![A-Fa-f0-9]{2}))/',
+            '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]+|%(?![A-Fa-f0-9]{2}))/u',
             [$this, 'urlEncodeChar'],
             $value
         );

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -588,6 +588,24 @@ class UriTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider utf8QueryStringsDataProvider
+     */
+    public function testUtf8Query($url, $result)
+    {
+        $uri = new Uri($url);
+
+        $this->assertEquals($result, $uri->getQuery());
+    }
+
+    public function utf8QueryStringsDataProvider()
+    {
+        return [
+            ['http://example.com/?q=тестовый_путь', 'q=тестовый_путь'],
+            ['http://example.com/?q=ουτοπία', 'q=ουτοπία'],
+        ];
+    }
+
     public function testUriDoesNotAppendColonToHostIfPortIsEmpty()
     {
         $uri = (new Uri())->withHost('google.com');


### PR DESCRIPTION
https://github.com/zendframework/zend-diactoros/pull/159 adds support for UTF-8 in host, and https://github.com/zendframework/zend-diactoros/pull/166 for path, but the query string still lacks UTF-8 support.