### PR TITLE
Actually accept string as body of ServerRequest

### DIFF
--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -64,7 +64,14 @@ trait RequestTrait
 
         $this->method = $method ?: '';
         $this->uri    = $this->createUri($uri);
-        $this->stream = $this->getStream($body, 'wb+');
+        try {
+            $this->stream = $this->getStream($body, 'wb+');
+        } catch (\InvalidArgumentException $e) {
+            $stream = fopen('php://memory', 'r+');
+            fwrite($stream, $body);
+            rewind($stream);
+            $this->stream = $stream;
+        }
 
         list($this->headerNames, $headers) = $this->filterHeaders($headers);
         $this->assertHeaders($headers);


### PR DESCRIPTION
The docblock and common sense suggest that ServerRequest constructor can accept $body as a string.
However doing so is not detected and code think that passed string is stream name.
I'm not sure if this is by design, it's a proposal, but in tests It's possible to pass a string as body.

Code suggested is just a quick scratch, elaboration needed.

Now I construct a `php://memory` stream and pass it to ServerRequest.