### PR TITLE
Added a getter for the temp file-name

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -219,6 +219,14 @@ class UploadedFile implements UploadedFileInterface
     public function getClientMediaType()
     {
         return $this->clientMediaType;
+    }   
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFile()
+    {
+        return $this->file;
     }
 
     /**


### PR DESCRIPTION
I want to be able to access the temp file-name of an uploaded file.

The specific case where i ran into this was handling a uploaded file to be imported by PHPExcel. PHPExcel only allows loading files from a filename and not from a stream for example.
I have no interest in writing the file away when i dont have to and no interest in keeping the file after the request has been handled.
Though you could argue the is a PHPExcel problem (and I agree), I see no reason to not allow a getter for the temp-file-name.