### PR TITLE
Improves SapiStreamEmitter tests, preventing unnecessary string casts

### DIFF
--- a/src/Response/SapiStreamEmitter.php
+++ b/src/Response/SapiStreamEmitter.php
@@ -64,6 +64,7 @@ class SapiStreamEmitter implements EmitterInterface
 
         if (! $body->isReadable()) {
             echo $body;
+            return;
         }
 
         while (! $body->eof()) {
@@ -94,6 +95,7 @@ class SapiStreamEmitter implements EmitterInterface
 
         if (! $body->isReadable()) {
             echo substr($body->getContents(), $first, $length);
+            return;
         }
 
         $remaining = $length;

--- a/test/Response/SapiStreamEmitterTest.php
+++ b/test/Response/SapiStreamEmitterTest.php
@@ -365,8 +365,15 @@ class SapiStreamEmitterTest extends SapiEmitterTest
     /**
      * @dataProvider emitMemoryUsageProvider
      */
-    public function testEmitMemoryUsage($seekable, $readable, $sizeBlocks, $maxAllowedBlocks, $rangeBlocks, $maxBufferLength)
-    {
+    public function testEmitMemoryUsage(
+        $seekable,
+        $readable,
+        $sizeBlocks,
+        $maxAllowedBlocks,
+        $rangeBlocks,
+        $maxBufferLength
+    ) {
+
         $sizeBytes = $maxBufferLength * $sizeBlocks;
         $maxAllowedMemoryUsage = $maxBufferLength * $maxAllowedBlocks;
         $peakBufferLength = 0;
@@ -442,6 +449,31 @@ class SapiStreamEmitterTest extends SapiEmitterTest
             ['bytes 3-6/*', 'Hello world', 'lo w'],
             ['items 0-0/1', 'Hello world', 'Hello world'],
         ];
+    }
+
+    public function emitJsonResponseProvider()
+    {
+        return [[0.1],
+                ['test'],
+                [true],
+                [1],
+                [['key1' => 'value1']],
+                [null],
+                [[[0.1, 0.2], ['test', 'test2'], [true, false], ['key1' => 'value1'], [null]]],
+        ];
+    }
+
+    /**
+     * @dataProvider emitJsonResponseProvider
+     */
+    public function testEmitJsonResponse($contents)
+    {
+        $response = (new JsonResponse($contents))
+            ->withStatus(200);
+
+        ob_start();
+        $this->emitter->emit($response);
+        $this->assertEquals(json_encode($contents), ob_get_clean());
     }
 
     /**


### PR DESCRIPTION
@Ocramius 

I tried to improve some points in the SapiStreamEmitter tests:

- Reduced code repetition by creating a new method for the Stream Prophecy common code.

- Added a method for expanding the test data set. This facilitates the addition of new data set with one information changed (e.g.: the contents).

- Improved checks of methods that can or cannot be called.

- Removed  the expectation of read counts because the buffer size is the maximum, the implementation can use a smaller one if you want.

- Considering bug #225, which I was not able to reproduce, both in the test and in an Expressive application. Added new tests for each type of response, checking what was emitted, and whether the content type was not changed.

Just a few comments:

- I didn't add out of range conditions to the tests (in testEmitRangeStreamResponse). I think that the application should handle this type of case, and it may be not possible to detect this type of condition in non seekable bodies.

- Please keep prophecy prediction after reveal. The Prophecy don't calls promise if it signature don't match exact with prediction signature.
E.g.:  $stream->seek(Argument::type('integer'), Argument::any()); vs $stream->seek($first)->should($seekPredictionClosure); and $ stream->seek($first, SEEK_SET)->should($seekPredictionClosure);
This occurs because signatures generate three different prophecies, one with a promise and two with a prediction, on execution only highest rated prophecy is executed. If you pass the "$first" value, only first prediction would be executed.

Linked to #224, #223