### PR TITLE
SapiStreamEmitter, consistent method arguments to call from Server::listen()

### DIFF
--- a/src/Response/SapiStreamEmitter.php
+++ b/src/Response/SapiStreamEmitter.php
@@ -24,9 +24,10 @@ class SapiStreamEmitter implements EmitterInterface
      * body content via the output buffer.
      *
      * @param ResponseInterface $response
+     * @param null|int $maxBufferLevel Maximum output buffering level to unwrap.
      * @param int $maxBufferLength Maximum output buffering size for each iteration
      */
-    public function emit(ResponseInterface $response, $maxBufferLength = 8192)
+    public function emit(ResponseInterface $response, $maxBufferLevel = null, $maxBufferLength = 8192)
     {
         if (headers_sent()) {
             throw new RuntimeException('Unable to emit response; headers already sent');
@@ -36,7 +37,7 @@ class SapiStreamEmitter implements EmitterInterface
 
         $this->emitStatusLine($response);
         $this->emitHeaders($response);
-        $this->flush();
+        $this->flush($maxBufferLevel);
 
         $range = $this->parseContentRange($response->getHeaderLine('Content-Range'));
 

--- a/test/Response/SapiStreamEmitterTest.php
+++ b/test/Response/SapiStreamEmitterTest.php
@@ -209,7 +209,7 @@ class SapiStreamEmitterTest extends SapiEmitterTest
             ->withBody($stream->reveal());
 
         ob_start();
-        $this->emitter->emit($response, $maxBufferLength);
+        $this->emitter->emit($response, null, $maxBufferLength);
         $emittedContents = ob_get_clean();
 
         if ($seekable) {
@@ -350,7 +350,7 @@ class SapiStreamEmitterTest extends SapiEmitterTest
             ->withBody($stream->reveal());
 
         ob_start();
-        $this->emitter->emit($response, $maxBufferLength);
+        $this->emitter->emit($response, null, $maxBufferLength);
         $emittedContents = ob_get_clean();
 
         $stream->rewind()->shouldNotBeCalled();
@@ -496,7 +496,7 @@ class SapiStreamEmitterTest extends SapiEmitterTest
 
         gc_disable();
 
-        $this->emitter->emit($response, $maxBufferLength);
+        $this->emitter->emit($response, null, $maxBufferLength);
 
         ob_end_flush();
 


### PR DESCRIPTION
currently (1.3.10), in Server class.
```
$this->getEmitter()->emit($response, $bufferLevel); 
```

but, `SapiStreamEmitter::emit()` defines 
```
public function emit(ResponseInterface $response, $maxBufferLength = 8192)
````

despite setting `$server->setEmitter(new \Zend\Diactoros\Response\SapiStreamEmitter());`

`emit` method argument is $response, $bufferLevel (not $maxBufferLength).