### PR TITLE
Prefix authority with double slash if present.

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -470,11 +470,11 @@ class Uri implements UriInterface
         $uri = '';
 
         if (! empty($scheme)) {
-            $uri .= sprintf('%s://', $scheme);
+            $uri .= sprintf('%s:', $scheme);
         }
 
         if (! empty($authority)) {
-            $uri .= $authority;
+            $uri .= '//' . $authority;
         }
 
         if ($path) {

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -609,6 +609,12 @@ class UriTest extends TestCase
     public function testUriDoesNotAppendColonToHostIfPortIsEmpty()
     {
         $uri = (new Uri())->withHost('google.com');
-        $this->assertEquals('google.com', (string) $uri);
+        $this->assertEquals('//google.com', (string) $uri);
+    }
+
+    public function testAuthorityIsPrefixedByDoubleSlashIfPresent()
+    {
+        $uri = (new Uri())->withHost('example.com');
+        $this->assertEquals('//example.com', (string) $uri);
     }
 }


### PR DESCRIPTION
The PSR-7 docblock of the `UriInterface::__toString` method, states that:

> If an authority is present, it MUST be prefixed by "//".

This PR tests and fixes that behavior.