### PR TITLE
Use the HTTP cookie header when available, instead of the  super global

### DIFF
--- a/doc/book/usage.md
+++ b/doc/book/usage.md
@@ -87,6 +87,13 @@ $request = Zend\Diactoros\ServerRequestFactory::fromGlobals(
 );
 ```
 
+When no cookie array is supplied, `fromGlobals` will first try to parse the supplied `cookie` header
+before falling back to the `$_COOKIE` superglobal. This is done because PHP has some legacy handling
+for request parameters which were then registered as global variables. Due to this, cookies with a period
+in the name were renamed with underlines. By getting the cookies directly from the cookie header, you have
+access to the original cookies in the way you set them in your application and they are send by the user
+agent.
+
 ### Manipulating the response
 
 Use the response object to add headers and provide content for the response.  Writing to the body

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -60,6 +60,10 @@ abstract class ServerRequestFactory
         $files   = static::normalizeFiles($files ?: $_FILES);
         $headers = static::marshalHeaders($server);
 
+        if (null === $cookies && array_key_exists('cookie', $headers)) {
+            $cookies = self::parseCookieHeader($headers['cookie']);
+        }
+
         return new ServerRequest(
             $server,
             $files,
@@ -484,5 +488,35 @@ abstract class ServerRequestFactory
         }
 
         return $matches['version'];
+    }
+
+    /**
+     * Parse a cookie header according to RFC 6265.
+     *
+     * PHP will replace special characters in cookie names, which results in other cookies not being available due to
+     * overwriting. Thus, the server request should take the cookies from the request header instead.
+     *
+     * @param $cookieHeader
+     * @return array
+     */
+    private static function parseCookieHeader($cookieHeader)
+    {
+        preg_match_all('(
+            (?:^\\n?[ \t]*|;[ ])
+            (?P<name>[!#$%&\'*+-.0-9A-Z^_`a-z|~]+)
+            =
+            (?P<DQUOTE>"?)
+                (?P<value>[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*)
+            (?P=DQUOTE)
+            (?=\\n?[ \t]*$|;[ ])
+        )x', $cookieHeader, $matches, PREG_SET_ORDER);
+
+        $cookies = [];
+
+        foreach ($matches as $match) {
+            $cookies[$match['name']] = urldecode($match['value']);
+        }
+
+        return $cookies;
     }
 }


### PR DESCRIPTION
PHP will replace special characters in cookie names, which results in other cookies not being available due to overwriting. Thus, the server request should take the cookies from the request header instead.