### PR TITLE
Exceptionally SapiEmitter is allowed to call emit with 2nd arguments

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -167,7 +167,13 @@ class Server
         if (! $response instanceof ResponseInterface) {
             $response = $this->response;
         }
-        $this->getEmitter()->emit($response, $bufferLevel);
+
+        $emitter = $this->getEmitter();
+        if ($emitter instanceof Response\SapiEmitter) {
+            $emitter->emit($response, $bufferLevel);
+        } else {
+            $emitter->emit($response);
+        }
     }
 
     /**

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -305,4 +305,21 @@ class ServerTest extends TestCase
         ob_end_flush();
         $this->assertTrue($invoked);
     }
+
+    public function testSapiEmmiterCallWithBufferLevel()
+    {
+        $server = new Server(
+            $this->callback,
+            $this->request,
+            $this->response
+        );
+        $emmiter = $this->getMockBuilder('Zend\Diactoros\Response\SapiEmitter')->getMock();
+        $emmiter->expects($this->once())
+            ->method('emit')
+            ->with($this->equalTo($this->response), $this->equalTo(2));
+
+        $server->setEmitter($emmiter);
+        $server->listen();
+        ob_end_flush();
+    }
 }


### PR DESCRIPTION
Exceptionally SapiEmitter is allowed to call emit with 2nd arguments - bufferLevel
 - EmitterInterface defines only 1st arguments

To fix non-consistentcy method arguments in Server::listen() #233 