### PR TITLE
__toString() always return empty content when resource is not seekable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - $HOME/.local
     - zf-mkdoc-theme
 
+dist: trusty
+
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -48,7 +48,9 @@ final class RelativeStream implements StreamInterface
      */
     public function __toString()
     {
-        $this->seek(0);
+        if ($this->isSeekable()) {
+            $this->seek(0);
+        }
         return $this->getContents();
     }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -48,7 +48,10 @@ class Stream implements StreamInterface
         }
 
         try {
-            $this->rewind();
+            if ($this->isSeekable()) {
+                $this->rewind();
+            }
+
             return $this->getContents();
         } catch (RuntimeException $e) {
             return '';

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -22,6 +22,7 @@ class RelativeStreamTest extends TestCase
     public function testToString()
     {
         $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->isSeekable()->willReturn(true);
         $decorated->tell()->willReturn(100);
         $decorated->seek(100, SEEK_SET)->shouldBeCalled();
         $decorated->getContents()->shouldBeCalled()->willReturn('foobarbaz');
@@ -185,7 +186,7 @@ class RelativeStreamTest extends TestCase
         $decorated = $this->prophesize('Zend\Diactoros\Stream');
         $decorated->isSeekable()->willReturn(false);
         $decorated->seek(Argument::any())->shouldNotBeCalled();
-        $decorated->tell()->willReturn(0);
+        $decorated->tell()->willReturn(3);
         $decorated->getContents()->willReturn('CONTENTS');
 
         $stream = new RelativeStream($decorated->reveal(), 3);

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Diactoros;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
 use Zend\Diactoros\RelativeStream;
 use Zend\Diactoros\Stream;
 
@@ -177,5 +178,17 @@ class RelativeStreamTest extends TestCase
         $decorated->getContents()->shouldNotBeCalled();
         $stream = new RelativeStream($decorated->reveal(), 100);
         $stream->getContents();
+    }
+
+    public function testCanReadContentFromNotSeekableResource()
+    {
+        $decorated = $this->prophesize('Zend\Diactoros\Stream');
+        $decorated->isSeekable()->willReturn(false);
+        $decorated->seek(Argument::any())->shouldNotBeCalled();
+        $decorated->tell()->willReturn(0);
+        $decorated->getContents()->willReturn('CONTENTS');
+
+        $stream = new RelativeStream($decorated->reveal(), 3);
+        $this->assertEquals('CONTENTS', $stream->__toString());
     }
 }

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -590,4 +590,21 @@ class StreamTest extends TestCase
 
         return false;
     }
+
+    public function testCanReadContentFromNotSeekableResource()
+    {
+        $this->tmpnam = tempnam(sys_get_temp_dir(), 'diac');
+        file_put_contents($this->tmpnam, 'FOO BAR');
+        $resource = fopen($this->tmpnam, 'r');
+        $stream = $this
+            ->getMockBuilder('Zend\Diactoros\Stream')
+            ->setConstructorArgs([$resource])
+            ->setMethods(['isSeekable'])
+            ->getMock();
+
+        $stream->expects($this->any())->method('isSeekable')
+            ->will($this->returnValue(false));
+
+        $this->assertEquals('FOO BAR', $stream->__toString());
+    }
 }


### PR DESCRIPTION
I have noticed this with amazon S3 it does return resource with meta `seekable => false` and I can't use this I have to create file and the n create new stream from it. Also does not make sense to rewind not seekable stream.