### PR TITLE
Encode user info when calling withUserInfo()

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -166,6 +166,10 @@ class Uri implements UriInterface
     }
 
     /**
+     * Retrieve the user-info part of the URI.
+     *
+     * This value is percent-encoded, per RFC 3986 Section 3.2.1.
+     *
      * {@inheritdoc}
      */
     public function getUserInfo()
@@ -242,6 +246,11 @@ class Uri implements UriInterface
     }
 
     /**
+     * Create and return a new instance containing the provided user credentials.
+     *
+     * The value will be percent-encoded in the new instance, but with measures
+     * taken to prevent double-encoding.
+     *
      * {@inheritdoc}
      */
     public function withUserInfo($user, $password = null)

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -443,7 +443,7 @@ class Uri implements UriInterface
         }
 
         $this->scheme    = isset($parts['scheme']) ? $this->filterScheme($parts['scheme']) : '';
-        $this->userInfo  = isset($parts['user']) ? $parts['user'] : '';
+        $this->userInfo  = isset($parts['user']) ? $this->filterUserInfoPart($parts['user']) : '';
         $this->host      = isset($parts['host']) ? $parts['host'] : '';
         $this->port      = isset($parts['port']) ? $parts['port'] : null;
         $this->path      = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
@@ -555,8 +555,10 @@ class Uri implements UriInterface
      */
     private function filterUserInfoPart($part)
     {
+        // Note the addition of `%` to initial charset; this allows `|` portion
+        // to match and thus prevent double-encoding.
         return preg_replace_callback(
-            '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ']+|%(?![A-Fa-f0-9]{2}))/u',
+            '/(?:[^%' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ']+|%(?![A-Fa-f0-9]{2}))/u',
             [$this, 'urlEncodeChar'],
             $part
         );

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -25,14 +25,14 @@ use Psr\Http\Message\UriInterface;
 class Uri implements UriInterface
 {
     /**
-     * Sub-delimiters used in query strings and fragments.
+     * Sub-delimiters used in user info, query strings and fragments.
      *
      * @const string
      */
     const CHAR_SUB_DELIMS = '!\$&\'\(\)\*\+,;=';
 
     /**
-     * Unreserved characters used in paths, query strings, and fragments.
+     * Unreserved characters used in user info, paths, query strings, and fragments.
      *
      * @const string
      */
@@ -261,9 +261,9 @@ class Uri implements UriInterface
             ));
         }
 
-        $info = $user;
+        $info = $this->filterUserInfoPart($user);
         if ($password) {
-            $info .= ':' . $password;
+            $info .= ':' . $this->filterUserInfoPart($password);
         }
 
         if ($info === $this->userInfo) {
@@ -545,6 +545,21 @@ class Uri implements UriInterface
         }
 
         return $scheme;
+    }
+
+    /**
+     * Filters a part of user info in a URI to ensure it is properly encoded.
+     *
+     * @param string $part
+     * @return string
+     */
+    private function filterUserInfoPart($part)
+    {
+        return preg_replace_callback(
+            '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . ']+|%(?![A-Fa-f0-9]{2}))/u',
+            [$this, 'urlEncodeChar'],
+            $part
+        );
     }
 
     /**

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -89,6 +89,14 @@ class UriTest extends TestCase
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
+    public function testWithUserInfoEncodesUsernameAndPassword()
+    {
+        $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
+        $new = $uri->withUserInfo('foo:bar', 'baz:bat');
+
+        $this->assertSame('foo%3Abar:baz%3Abat', $new->getUserInfo());
+    }
+
     public function testWithHostReturnsNewInstanceWithProvidedHost()
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -89,12 +89,28 @@ class UriTest extends TestCase
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    public function testWithUserInfoEncodesUsernameAndPassword()
+    public function userInfoProvider()
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            // name       => [ user,              credential, expected ]
+            'valid-chars' => ['foo',              'bar',      'foo:bar'],
+            'colon'       => ['foo:bar',          'baz:bat',  'foo%3Abar:baz%3Abat'],
+            'at'          => ['user@example.com', 'cred@foo', 'user%40example.com:cred%40foo'],
+            'percent'     => ['%25',              '%25',      '%2525:%2525'],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider userInfoProvider
+     */
+    public function testWithUserInfoEncodesUsernameAndPassword($user, $credential, $expected)
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
-        $new = $uri->withUserInfo('foo:bar', 'baz:bat');
+        $new = $uri->withUserInfo($user, $credential);
 
-        $this->assertSame('foo%3Abar:baz%3Abat', $new->getUserInfo());
+        $this->assertSame($expected, $new->getUserInfo());
     }
 
     public function testWithHostReturnsNewInstanceWithProvidedHost()

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -97,7 +97,8 @@ class UriTest extends TestCase
             'valid-chars' => ['foo',              'bar',      'foo:bar'],
             'colon'       => ['foo:bar',          'baz:bat',  'foo%3Abar:baz%3Abat'],
             'at'          => ['user@example.com', 'cred@foo', 'user%40example.com:cred%40foo'],
-            'percent'     => ['%25',              '%25',      '%2525:%2525'],
+            'percent'     => ['%25',              '%25',      '%25:%25'],
+            'invalid-enc' => ['%ZZ',              '%GG',      '%25ZZ:%25GG'],
         ];
         // @codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
According to <https://www.ietf.org/rfc/rfc3986.txt> 3.2.1, the user info parts should actually be URL encoded.