### PR TITLE
Do not create a new instance when nothing changed

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -232,7 +232,7 @@ class Uri implements UriInterface
 
         if ($scheme === $this->scheme) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;
@@ -268,7 +268,7 @@ class Uri implements UriInterface
 
         if ($info === $this->userInfo) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;
@@ -292,7 +292,7 @@ class Uri implements UriInterface
 
         if ($host === $this->host) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;
@@ -319,7 +319,7 @@ class Uri implements UriInterface
 
         if ($port === $this->port) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         if ($port !== null && $port < 1 || $port > 65535) {
@@ -362,7 +362,7 @@ class Uri implements UriInterface
 
         if ($path === $this->path) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;
@@ -392,7 +392,7 @@ class Uri implements UriInterface
 
         if ($query === $this->query) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;
@@ -418,7 +418,7 @@ class Uri implements UriInterface
 
         if ($fragment === $this->fragment) {
             // Do nothing if no change was made.
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -43,11 +43,11 @@ class UriTest extends TestCase
         $this->assertEquals('http://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    public function testWithSchemeReturnsNewInstanceWithSameScheme()
+    public function testWithSchemeReturnsSameInstanceWithSameScheme()
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
         $new = $uri->withScheme('https');
-        $this->assertNotSame($uri, $new);
+        $this->assertSame($uri, $new);
         $this->assertEquals('https', $new->getScheme());
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
@@ -78,11 +78,11 @@ class UriTest extends TestCase
         $uri->withUserInfo('matthew', 1);
     }
 
-    public function testWithUserInfoReturnsNewInstanceIfUserAndPasswordAreSameAsBefore()
+    public function testWithUserInfoReturnsSameInstanceIfUserAndPasswordAreSameAsBefore()
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
         $new = $uri->withUserInfo('user', 'pass');
-        $this->assertNotSame($uri, $new);
+        $this->assertSame($uri, $new);
         $this->assertEquals('user:pass', $new->getUserInfo());
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
@@ -96,11 +96,11 @@ class UriTest extends TestCase
         $this->assertEquals('https://user:pass@framework.zend.com:3001/foo?bar=baz#quz', (string) $new);
     }
 
-    public function testWithHostReturnsNewInstanceWithProvidedHostIsSameAsBefore()
+    public function testWithHostReturnsSameInstanceWithProvidedHostIsSameAsBefore()
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
         $new = $uri->withHost('local.example.com');
-        $this->assertNotSame($uri, $new);
+        $this->assertSame($uri, $new);
         $this->assertEquals('local.example.com', $new->getHost());
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
@@ -111,7 +111,6 @@ class UriTest extends TestCase
             'null'         => [ null ],
             'int'          => [ 3000 ],
             'string'       => [ "3000" ],
-            'sameasbefore' => [ "3001" ],
         ];
     }
 
@@ -128,6 +127,14 @@ class UriTest extends TestCase
             sprintf('https://user:pass@local.example.com%s/foo?bar=baz#quz', $port === null ? '' : ':' . $port),
             (string) $new
         );
+    }
+
+    public function testWithPortReturnsSameInstanceWithProvidedPortIsSameAsBefore()
+    {
+        $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
+        $new = $uri->withPort('3001');
+        $this->assertSame($uri, $new);
+        $this->assertEquals('3001', $new->getPort());
     }
 
     public function invalidPorts()
@@ -163,11 +170,11 @@ class UriTest extends TestCase
         $this->assertEquals('https://user:pass@local.example.com:3001/bar/baz?bar=baz#quz', (string) $new);
     }
 
-    public function testWithPathReturnsNewInstanceWithProvidedPathSameAsBefore()
+    public function testWithPathReturnsSameInstanceWithProvidedPathSameAsBefore()
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
         $new = $uri->withPath('/foo');
-        $this->assertNotSame($uri, $new);
+        $this->assertSame($uri, $new);
         $this->assertEquals('/foo', $new->getPath());
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }
@@ -235,11 +242,11 @@ class UriTest extends TestCase
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#qat', (string) $new);
     }
 
-    public function testWithFragmentReturnsNewInstanceWithProvidedFragmentSameAsBefore()
+    public function testWithFragmentReturnsSameInstanceWithProvidedFragmentSameAsBefore()
     {
         $uri = new Uri('https://user:pass@local.example.com:3001/foo?bar=baz#quz');
         $new = $uri->withFragment('quz');
-        $this->assertNotSame($uri, $new);
+        $this->assertSame($uri, $new);
         $this->assertEquals('quz', $new->getFragment());
         $this->assertEquals('https://user:pass@local.example.com:3001/foo?bar=baz#quz', (string) $new);
     }


### PR DESCRIPTION
When not changing an object through one of the immutable methods, there is no need to return a cloned instance with the exact same properties.