### PR TITLE
JsonResponse additional API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- adds new API to `JsonResponse` to avoid having to decode the body to make changes to the underlying content: `getPayload()`, `withPayload()`, `getEncodingOptions()`, `withEncodingOptions()`.
 
 ### Deprecated
 

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -69,7 +69,7 @@ class JsonResponse extends Response
         array $headers = [],
         $encodingOptions = self::DEFAULT_JSON_FLAGS
     ) {
-        $this->payload = $data;
+        $this->setPayload($data);
         $this->encodingOptions = $encodingOptions;
 
         $json = $this->jsonEncode($data, $this->encodingOptions);
@@ -106,7 +106,8 @@ class JsonResponse extends Response
     public function withPayload($data)
     {
         $new = clone $this;
-        $new->payload = $data;
+
+        $new->setPayload($data);
 
         $json = $this->jsonEncode($new->payload, $new->encodingOptions);
         $body = $this->createBodyFromJson($json);
@@ -183,5 +184,19 @@ class JsonResponse extends Response
         }
 
         return $json;
+    }
+
+    /**
+     * @param $data
+     *
+     * @return mixed
+     */
+    private function setPayload($data)
+    {
+        if (is_object($data)) {
+            $data = clone $data;
+        }
+
+        $this->payload = $data;
     }
 }

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -81,16 +81,6 @@ class JsonResponse extends Response
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getBody()
-    {
-        $body = parent::getBody();
-
-        return $body;
-    }
-
-    /**
      * @return mixed
      */
     public function getPayload()
@@ -188,8 +178,6 @@ class JsonResponse extends Response
 
     /**
      * @param $data
-     *
-     * @return mixed
      */
     private function setPayload($data)
     {

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -140,7 +140,7 @@ class JsonResponseTest extends TestCase
     {
         $payload = ['test' => 'data'];
         $response = new JsonResponse($payload);
-        $this->assertSame($payload, $response->getPayload());
+        $this->assertEquals($payload, $response->getPayload());
     }
 
     public function testWithPayload()
@@ -149,7 +149,7 @@ class JsonResponseTest extends TestCase
         $json = [ 'foo' => 'bar'];
         $response = $response->withPayload($json);
 
-        $this->assertSame($json, $response->getPayload());
+        $this->assertEquals($json, $response->getPayload());
         $decodedBody = json_decode($response->getBody()->getContents(), true);
         $this->assertEquals($json, $decodedBody);
     }
@@ -178,5 +178,19 @@ JSON;
 JSON;
 
         $this->assertSame($expected, $response->getBody()->getContents());
+    }
+
+    public function testModifyingThePayloadDoesntMutateResponseInstance()
+    {
+        $payload = new \stdClass();
+        $payload->foo = 'bar';
+
+        $response = new JsonResponse($payload);
+
+        $originalPayload = clone $payload;
+        $payload->bar = 'baz';
+
+        $this->assertEquals($originalPayload, $response->getPayload());
+        $this->assertNotEquals($payload, $response->getPayload());
     }
 }

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -147,10 +147,11 @@ class JsonResponseTest extends TestCase
     {
         $response = new JsonResponse(['test' => 'data']);
         $json = [ 'foo' => 'bar'];
-        $response = $response->withPayload($json);
+        $newResponse = $response->withPayload($json);
+        $this->assertNotSame($response, $newResponse);
 
-        $this->assertEquals($json, $response->getPayload());
-        $decodedBody = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals($json, $newResponse->getPayload());
+        $decodedBody = json_decode($newResponse->getBody()->getContents(), true);
         $this->assertEquals($json, $decodedBody);
     }
 
@@ -169,7 +170,9 @@ JSON;
 
         $this->assertSame($expected, $response->getBody()->getContents());
 
-        $response = $response->withEncodingOptions(JSON_PRETTY_PRINT);
+        $newResponse = $response->withEncodingOptions(JSON_PRETTY_PRINT);
+
+        $this->assertNotSame($response, $newResponse);
 
         $expected = <<<JSON
 {
@@ -177,7 +180,7 @@ JSON;
 }
 JSON;
 
-        $this->assertSame($expected, $response->getBody()->getContents());
+        $this->assertSame($expected, $newResponse->getBody()->getContents());
     }
 
     public function testModifyingThePayloadDoesntMutateResponseInstance()

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -135,4 +135,48 @@ class JsonResponseTest extends TestCase
         $actual = json_decode($response->getBody()->getContents(), true);
         $this->assertEquals($json, $actual);
     }
+
+    public function testPayloadGetter()
+    {
+        $payload = ['test' => 'data'];
+        $response = new JsonResponse($payload);
+        $this->assertSame($payload, $response->getPayload());
+    }
+
+    public function testWithPayload()
+    {
+        $response = new JsonResponse(['test' => 'data']);
+        $json = [ 'foo' => 'bar'];
+        $response = $response->withPayload($json);
+
+        $this->assertSame($json, $response->getPayload());
+        $decodedBody = json_decode($response->getBody()->getContents(), true);
+        $this->assertEquals($json, $decodedBody);
+    }
+
+    public function testEncodingOptionsGetter()
+    {
+        $response = new JsonResponse([]);
+        $this->assertSame(JsonResponse::DEFAULT_JSON_FLAGS, $response->getEncodingOptions());
+    }
+
+    public function testWithEncodingOptions()
+    {
+        $response = new JsonResponse([ 'foo' => 'bar']);
+        $expected = <<<JSON
+{"foo":"bar"}
+JSON;
+
+        $this->assertSame($expected, $response->getBody()->getContents());
+
+        $response = $response->withEncodingOptions(JSON_PRETTY_PRINT);
+
+        $expected = <<<JSON
+{
+    "foo": "bar"
+}
+JSON;
+
+        $this->assertSame($expected, $response->getBody()->getContents());
+    }
 }


### PR DESCRIPTION
This PR adds new API to `Zend\Diactoros\Response\JsonResponse`:

`withPayload($data)`
`getPayload()`
`withEncodingOptions($options)`
`getEncodingOptions()`

The constructor now holds a copy of the payload and its encoding options to let consumer modify the final content without having to get the body content, decode it, update it, and then re-invoke the full constructor.

The main use case that inspired this new functionality is adding metadata to a JSON down a middleware pipe, e.g. hypermedia links.

While the native PHP JSON parser is fast enough for simple use cases, this can become a problem with high loads and big JSONs; besides, what consumers must resolve to do is arguably in-elegant; here is an example of a middleware that adds a `self` link to a JSON response:

```php
$response = $delegate->process($request);

// [...] assert $response is Json

$body = $response->getBody();
$body->rewind();

$payload = json_decode($body->getContents(), true);

$currentUrl = $this->createCurrentUrl();

if (! isset($payload['links'])) {
    $payload['links'] = [];
}

$payload['links']['self'] = $currentUrl;

$jsonResponse = (new JsonResponse(
        $payload,
        $response->getStatusCode(),
        $response->getHeaders()
    ))
    ->withAddedHeader('Link', $currentUrl . '; rel="self"')
;

return $jsonResponse;
``` 

The initial idea was to avoid encoding the data in the constructor, but rather do it lazily in the `getBody` method; unfortunately, this would be backwards incompatible due to the validation of the payload happening in `__construct()`. This makes necessary to encode the payload as soon as the response is created, but at least now the decoding step can be avoided by getting the payload from the response and creating a new instance by invoking `withPayload($data)`;

So the new API enables to change the previous middlware example to this:

```php
$response = $delegate->process($request);

// [...] assert $response is Json

$payload = $response->getPayload();

$currentUrl = $this->createCurrentUrl();

if (! isset($payload['links'])) {
    $payload['links'] = [];
}

$payload['links']['self'] = $currentUrl;

$jsonResponse = $response
    ->withPayload($payload)
    ->withAddedHeader('Link', $currentUrl . '; rel="self"')
;

return $jsonResponse;
```

It may not seem like a big deal, but I think it is overall less wonky! :wink: 