### PR TITLE
PHP session cookies are no longer broken

### DIFF
--- a/src/Response/SapiEmitterTrait.php
+++ b/src/Response/SapiEmitterTrait.php
@@ -65,7 +65,7 @@ trait SapiEmitterTrait
     {
         foreach ($response->getHeaders() as $header => $values) {
             $name  = $this->filterHeader($header);
-            $first = true;
+            $first = $name === 'Set-Cookie' ? false : true;
             foreach ($values as $value) {
                 header(sprintf(
                     '%s: %s',


### PR DESCRIPTION
When using native PHP sessions with cookies, PHP will set a cookie whenever a session is created or regenerated. Adding an additional `Set-Cookie` header in the same request will cause the PHP `Set-Cookie` header to be lost. Ideally native PHP sessions with cookies should be avoided when using PSR-7 compatible classes, but that is not always possible - this PR makes sure PHP's session cookies are not lost.