### PR TITLE
fix #255 - Don't evaluate '0' as empty

### DIFF
--- a/src/PhpInputStream.php
+++ b/src/PhpInputStream.php
@@ -59,7 +59,7 @@ class PhpInputStream extends Stream
     public function read($length)
     {
         $content = parent::read($length);
-        if ($content && ! $this->reachedEof) {
+        if (! $this->reachedEof) {
             $this->cache .= $content;
         }
 

--- a/test/PhpInputStreamTest.php
+++ b/test/PhpInputStreamTest.php
@@ -64,6 +64,17 @@ class PhpInputStreamTest extends TestCase
         $this->assertEquals(substr($contents, 128), $remainder);
     }
 
+    public function testGetContentsReturnCacheWhenReachedEof()
+    {
+        $this->stream->getContents();
+        $this->assertStreamContents($this->stream->getContents());
+
+        $stream = new PhpInputStream('data://,0');
+        $stream->read(1);
+        $stream->read(1);
+        $this->assertSame('0', $stream->getContents(), 'Don\'t evaluate 0 as empty');
+    }
+
     public function testCastingToStringReturnsFullContentsRegardlesOfPriorReads()
     {
         $start = $this->stream->read(128);


### PR DESCRIPTION
Psr-7 StreamInterface::read() returns only string, so don't need check it is empty-like value
fix #255