### PR TITLE
dist: trusty for hhvm for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-
+dist: trusty
 language: php
 
 cache:


### PR DESCRIPTION
due to travis error: 
```
HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
```