### PR TITLE
Respect response's status code

### DIFF
--- a/src/Response/SapiEmitter.php
+++ b/src/Response/SapiEmitter.php
@@ -26,8 +26,8 @@ class SapiEmitter implements EmitterInterface
     {
         $this->assertNoPreviousOutput();
 
-        $this->emitStatusLine($response);
         $this->emitHeaders($response);
+        $this->emitStatusLine($response);
         $this->emitBody($response);
     }
 

--- a/src/Response/SapiEmitterTrait.php
+++ b/src/Response/SapiEmitterTrait.php
@@ -38,7 +38,13 @@ trait SapiEmitterTrait
      * Emits the status line using the protocol version and status code from
      * the response; if a reason phrase is available, it, too, is emitted.
      *
+     * It's important to mention that, in order to prevent PHP from changing
+     * the status code of the emitted response, this method should be called
+     * after `emitHeaders()`
+     *
      * @param ResponseInterface $response
+     *
+     * @see \Zend\Diactoros\Response\SapiEmitterTrait::emitHeaders()
      */
     private function emitStatusLine(ResponseInterface $response)
     {

--- a/src/Response/SapiEmitterTrait.php
+++ b/src/Response/SapiEmitterTrait.php
@@ -43,12 +43,14 @@ trait SapiEmitterTrait
     private function emitStatusLine(ResponseInterface $response)
     {
         $reasonPhrase = $response->getReasonPhrase();
+        $statusCode   = $response->getStatusCode();
+
         header(sprintf(
             'HTTP/%s %d%s',
             $response->getProtocolVersion(),
-            $response->getStatusCode(),
+            $statusCode,
             ($reasonPhrase ? ' ' . $reasonPhrase : '')
-        ));
+        ), true, $statusCode);
     }
 
     /**
@@ -63,6 +65,8 @@ trait SapiEmitterTrait
      */
     private function emitHeaders(ResponseInterface $response)
     {
+        $statusCode = $response->getStatusCode();
+
         foreach ($response->getHeaders() as $header => $values) {
             $name  = $this->filterHeader($header);
             $first = $name === 'Set-Cookie' ? false : true;
@@ -71,7 +75,7 @@ trait SapiEmitterTrait
                     '%s: %s',
                     $name,
                     $value
-                ), $first);
+                ), $first, $statusCode);
                 $first = false;
             }
         }

--- a/src/Response/SapiStreamEmitter.php
+++ b/src/Response/SapiStreamEmitter.php
@@ -27,8 +27,8 @@ class SapiStreamEmitter implements EmitterInterface
     public function emit(ResponseInterface $response, $maxBufferLength = 8192)
     {
         $this->assertNoPreviousOutput();
-        $this->emitStatusLine($response);
         $this->emitHeaders($response);
+        $this->emitStatusLine($response);
 
         $range = $this->parseContentRange($response->getHeaderLine('Content-Range'));
 

--- a/test/Response/AbstractEmitterTest.php
+++ b/test/Response/AbstractEmitterTest.php
@@ -66,9 +66,9 @@ abstract class AbstractEmitterTest extends TestCase
         $this->emitter->emit($response);
 
         $expectedStack = [
-            ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => 200],
             ['header' => 'Set-Cookie: foo=bar', 'replace' => false, 'status_code' => 200],
             ['header' => 'Set-Cookie: bar=baz', 'replace' => false, 'status_code' => 200],
+            ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => 200],
         ];
 
         $this->assertSame($expectedStack, HeaderStack::stack());
@@ -84,9 +84,9 @@ abstract class AbstractEmitterTest extends TestCase
         $this->emitter->emit($response);
 
         $expectedStack = [
-            ['header' => 'HTTP/1.1 202 Accepted', 'replace' => true, 'status_code' => 202],
             ['header' => 'Location: http://api.my-service.com/12345678', 'replace' => true, 'status_code' => 202],
             ['header' => 'Content-Type: text/plain', 'replace' => true, 'status_code' => 202],
+            ['header' => 'HTTP/1.1 202 Accepted', 'replace' => true, 'status_code' => 202],
         ];
 
         $this->assertSame($expectedStack, HeaderStack::stack());

--- a/test/Response/AbstractEmitterTest.php
+++ b/test/Response/AbstractEmitterTest.php
@@ -40,8 +40,9 @@ abstract class AbstractEmitterTest extends TestCase
         ob_start();
         $this->emitter->emit($response);
         ob_end_clean();
-        $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
-        $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
+
+        $this->assertTrue(HeaderStack::has('HTTP/1.1 200 OK'));
+        $this->assertTrue(HeaderStack::has('Content-Type: text/plain'));
     }
 
     public function testEmitsMessageBody()
@@ -68,7 +69,7 @@ abstract class AbstractEmitterTest extends TestCase
         $this->emitter->emit($response);
         ob_end_clean();
         foreach (HeaderStack::stack() as $header) {
-            $this->assertNotContains('Content-Length:', $header);
+            $this->assertNotContains('Content-Length:', $header['header']);
         }
     }
 }

--- a/test/Response/AbstractEmitterTest.php
+++ b/test/Response/AbstractEmitterTest.php
@@ -56,6 +56,24 @@ abstract class AbstractEmitterTest extends TestCase
         $this->emitter->emit($response);
     }
 
+    public function testMultipleSetCookieHeadersAreNotReplaced()
+    {
+        $response = (new Response())
+            ->withStatus(200)
+            ->withAddedHeader('Set-Cookie', 'foo=bar')
+            ->withAddedHeader('Set-Cookie', 'bar=baz');
+
+        $this->emitter->emit($response);
+
+        $expectedStack = [
+            ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => null],
+            ['header' => 'Set-Cookie: foo=bar', 'replace' => false, 'status_code' => null],
+            ['header' => 'Set-Cookie: bar=baz', 'replace' => false, 'status_code' => null],
+        ];
+
+        $this->assertSame($expectedStack, HeaderStack::stack());
+    }
+
     public function testDoesNotInjectContentLengthHeaderIfStreamSizeIsUnknown()
     {
         $stream = $this->prophesize('Psr\Http\Message\StreamInterface');

--- a/test/Response/AbstractEmitterTest.php
+++ b/test/Response/AbstractEmitterTest.php
@@ -66,9 +66,27 @@ abstract class AbstractEmitterTest extends TestCase
         $this->emitter->emit($response);
 
         $expectedStack = [
-            ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => null],
-            ['header' => 'Set-Cookie: foo=bar', 'replace' => false, 'status_code' => null],
-            ['header' => 'Set-Cookie: bar=baz', 'replace' => false, 'status_code' => null],
+            ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => 200],
+            ['header' => 'Set-Cookie: foo=bar', 'replace' => false, 'status_code' => 200],
+            ['header' => 'Set-Cookie: bar=baz', 'replace' => false, 'status_code' => 200],
+        ];
+
+        $this->assertSame($expectedStack, HeaderStack::stack());
+    }
+
+    public function testDoesNotLetResponseCodeBeOverriddenByPHP()
+    {
+        $response = (new Response())
+            ->withStatus(202)
+            ->withAddedHeader('Location', 'http://api.my-service.com/12345678')
+            ->withAddedHeader('Content-Type', 'text/plain');
+
+        $this->emitter->emit($response);
+
+        $expectedStack = [
+            ['header' => 'HTTP/1.1 202 Accepted', 'replace' => true, 'status_code' => 202],
+            ['header' => 'Location: http://api.my-service.com/12345678', 'replace' => true, 'status_code' => 202],
+            ['header' => 'Content-Type: text/plain', 'replace' => true, 'status_code' => 202],
         ];
 
         $this->assertSame($expectedStack, HeaderStack::stack());

--- a/test/Response/SapiStreamEmitterTest.php
+++ b/test/Response/SapiStreamEmitterTest.php
@@ -56,7 +56,7 @@ class SapiStreamEmitterTest extends AbstractEmitterTest
         $this->emitter->emit($response);
         ob_end_clean();
         foreach (HeaderStack::stack() as $header) {
-            $this->assertNotContains('Content-Length:', $header);
+            $this->assertNotContains('Content-Length:', $header['header']);
         }
     }
 

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -247,15 +247,22 @@ class ServerTest extends TestCase
     public function testHeaderOrderIsHonoredWhenEmitted($stack)
     {
         $header = array_pop($stack);
+        $this->assertContains('Content-Type: text/plain', $header);
+
+        $header = array_pop($stack);
         $this->assertContains(
             'Set-Cookie: bar=baz; expires=Wed, 8 Oct 2014 10:30; path=/foo/bar; domain=example.com',
             $header
         );
+
         $header = array_pop($stack);
         $this->assertContains(
             'Set-Cookie: foo=bar; expires=Wed, 1 Oct 2014 10:30; path=/foo; domain=example.com',
             $header
         );
+
+        $header = array_pop($stack);
+        $this->assertContains('HTTP/1.1 200 OK', $header);
     }
 
     public function testListenPassesCallableArgumentToCallback()

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -151,8 +151,8 @@ class ServerTest extends TestCase
         $this->expectOutputString('FOOBAR');
         $server->listen();
 
-        $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
-        $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
+        $this->assertTrue(HeaderStack::has('HTTP/1.1 200 OK'));
+        $this->assertTrue(HeaderStack::has('Content-Type: text/plain'));
     }
 
     public function testListenEmitsStatusHeaderWithoutReasonPhraseIfNoReasonPhrase()
@@ -176,8 +176,8 @@ class ServerTest extends TestCase
         $this->expectOutputString('FOOBAR');
         $server->listen();
 
-        $this->assertContains('HTTP/1.1 299', HeaderStack::stack());
-        $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
+        $this->assertTrue(HeaderStack::has('HTTP/1.1 299'));
+        $this->assertTrue(HeaderStack::has('Content-Type: text/plain'));
     }
 
     public function testEnsurePercentCharactersDoNotResultInOutputError()
@@ -200,8 +200,8 @@ class ServerTest extends TestCase
         $this->expectOutputString('100%');
         $server->listen();
 
-        $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
-        $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
+        $this->assertTrue(HeaderStack::has('HTTP/1.1 200 OK'));
+        $this->assertTrue(HeaderStack::has('Content-Type: text/plain'));
     }
 
     public function testEmitsHeadersWithMultipleValuesMultipleTimes()
@@ -228,19 +228,16 @@ class ServerTest extends TestCase
 
         $server->listen();
 
-        $this->assertContains('HTTP/1.1 200 OK', HeaderStack::stack());
-        $this->assertContains('Content-Type: text/plain', HeaderStack::stack());
-        $this->assertContains(
-            'Set-Cookie: foo=bar; expires=Wed, 1 Oct 2014 10:30; path=/foo; domain=example.com',
-            HeaderStack::stack()
+        $this->assertTrue(HeaderStack::has('HTTP/1.1 200 OK'));
+        $this->assertTrue(HeaderStack::has('Content-Type: text/plain'));
+        $this->assertTrue(
+            HeaderStack::has('Set-Cookie: foo=bar; expires=Wed, 1 Oct 2014 10:30; path=/foo; domain=example.com')
         );
-        $this->assertContains(
-            'Set-Cookie: bar=baz; expires=Wed, 8 Oct 2014 10:30; path=/foo/bar; domain=example.com',
-            HeaderStack::stack()
+        $this->assertTrue(
+            HeaderStack::has('Set-Cookie: bar=baz; expires=Wed, 8 Oct 2014 10:30; path=/foo/bar; domain=example.com')
         );
 
-        $stack  = HeaderStack::stack();
-        return $stack;
+        return HeaderStack::stack();
     }
 
     /**

--- a/test/TestAsset/Functions.php
+++ b/test/TestAsset/Functions.php
@@ -27,7 +27,7 @@ namespace ZendTest\Diactoros\TestAsset;
 class HeaderStack
 {
     /**
-     * @var array
+     * @var string[][]
      */
     private static $data = [];
 
@@ -42,9 +42,9 @@ class HeaderStack
     /**
      * Push a header on the stack
      *
-     * @param string $header
+     * @param string[] $header
      */
-    public static function push($header)
+    public static function push(array $header)
     {
         self::$data[] = $header;
     }
@@ -52,11 +52,29 @@ class HeaderStack
     /**
      * Return the current header stack
      *
-     * @return array
+     * @return string[][]
      */
     public static function stack()
     {
         return self::$data;
+    }
+
+    /**
+     * Verify if there's a header line on the stack
+     *
+     * @param string $header
+     *
+     * @return bool
+     */
+    public static function has($header)
+    {
+        foreach (self::$data as $item) {
+            if ($item['header'] === $header) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 
@@ -73,9 +91,17 @@ function headers_sent()
 /**
  * Emit a header, without creating actual output artifacts
  *
- * @param string $value
+ * @param string   $string
+ * @param bool     $replace
+ * @param int|null $statusCode
  */
-function header($value)
+function header($string, $replace = true, $statusCode = null)
 {
-    HeaderStack::push($value);
+    HeaderStack::push(
+        [
+            'header'      => $string,
+            'replace'     => $replace,
+            'status_code' => $statusCode,
+        ]
+    );
 }

--- a/test/TestAsset/SapiResponse.php
+++ b/test/TestAsset/SapiResponse.php
@@ -35,9 +35,17 @@ function headers_sent()
 /**
  * Emit a header, without creating actual output artifacts
  *
- * @param string $value
+ * @param string   $string
+ * @param bool     $replace
+ * @param int|null $http_response_code
  */
-function header($value)
+function header($string, $replace = true, $http_response_code = null)
 {
-    HeaderStack::push($value);
+    HeaderStack::push(
+        [
+            'header'      => $string,
+            'replace'     => $replace,
+            'status_code' => $http_response_code,
+        ]
+    );
 }


### PR DESCRIPTION
This basically ensures that `zend-diactoros` sends the status code to `header()` while emitting the response headers, preventing PHP from overriding it silently.

IMO this is a bug fix, since the emitted response is different from the created response.

We have a similar solution in `symfony/http-foundation`: https://github.com/symfony/http-foundation/blob/dd97248b62153457d0716738d0dbcc0c2b31e285/Response.php#L331-L338

More info:

- https://bugs.php.net/bug.php?id=70273
- https://bugs.php.net/bug.php?id=51749
- https://bugs.php.net/bug.php?id=74535