### PR TITLE
Nits on range check for port number, unnecessary sprintf

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -341,9 +341,9 @@ trait MessageTrait
     private function validateProtocolVersion($version)
     {
         if (empty($version)) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(
                 'HTTP protocol version can not be empty'
-            ));
+            );
         }
         if (! is_string($version)) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -329,7 +329,7 @@ class Uri implements UriInterface
             return $this;
         }
 
-        if ($port !== null && $port < 1 || $port > 65535) {
+        if ($port !== null && ($port < 1 || $port > 65535)) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid port "%d" specified; must be a valid TCP/UDP port',
                 $port


### PR DESCRIPTION
The old version would be parsed as `($port !== null && $port < 1) || ...`

(That'd have the same results for `null` and `0`,
but is less readable)