### PR TITLE
Do not include coverage uploading in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
   - if [[ $CHECK_CS == 'true' ]]; then composer cs-check ; fi
 
 after_script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry php vendor/bin/php-coveralls -v ; fi
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
     "cs-check": "phpcs",
     "cs-fix": "phpcbf",
     "test": "phpunit --colors=always",
-    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-    "upload-coverage": "php-coveralls -v"
+    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
   }
 }


### PR DESCRIPTION
Coverage reporting is only used on a single target, and is only installed conditionally via Travis, so we should not have scripts for uploading coverage within our `composer.json`.