### PR TITLE
check fstat result

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -103,7 +103,11 @@ class Stream implements StreamInterface
         }
 
         $stats = fstat($this->resource);
-        return $stats['size'];
+        if (false !=== $stats) {
+            return $stats['size'];
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
`fstats` may not work with every type of resource ('php://input' streams for instance and remote file pointers).