### PR TITLE
remove superfluous $scheme empty test

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -244,9 +244,7 @@ abstract class ServerRequestFactory
         ) {
             $scheme = 'https';
         }
-        if (! empty($scheme)) {
-            $uri = $uri->withScheme($scheme);
-        }
+        $uri = $uri->withScheme($scheme);
 
         // Set the host
         $accumulator = (object) ['host' => '', 'port' => null];


### PR DESCRIPTION
`$scheme` is never empty as it was initialized to `'http'`