### PR TITLE
`getHost` returns always lowercase hostname (PSR-7 spec)

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -303,7 +303,7 @@ class Uri implements UriInterface
         }
 
         $new = clone $this;
-        $new->host = $host;
+        $new->host = strtolower($host);
 
         return $new;
     }
@@ -451,7 +451,7 @@ class Uri implements UriInterface
 
         $this->scheme    = isset($parts['scheme']) ? $this->filterScheme($parts['scheme']) : '';
         $this->userInfo  = isset($parts['user']) ? $this->filterUserInfoPart($parts['user']) : '';
-        $this->host      = isset($parts['host']) ? $parts['host'] : '';
+        $this->host      = isset($parts['host']) ? strtolower($parts['host']) : '';
         $this->port      = isset($parts['port']) ? $parts['port'] : null;
         $this->path      = isset($parts['path']) ? $this->filterPath($parts['path']) : '';
         $this->query     = isset($parts['query']) ? $this->filterQuery($parts['query']) : '';

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -677,4 +677,16 @@ class UriTest extends TestCase
 
         $this->assertContains('/v1/people/~:(first-name,last-name,email-address,picture-url)', (string) $uri);
     }
+
+    public function testHostIsLowercase()
+    {
+        $uri = new Uri('http://HOST.LOC/path?q=1');
+        $this->assertSame('host.loc', $uri->getHost());
+    }
+
+    public function testHostIsLowercaseWhenIsSetViwWithHost()
+    {
+        $uri = (new Uri())->withHost('NEW-HOST.COM');
+        $this->assertSame('new-host.com', $uri->getHost());
+    }
 }


### PR DESCRIPTION
Fixes #292