### PR TITLE
make string comparison more strict

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -98,7 +98,7 @@ class Uri implements UriInterface
             ));
         }
 
-        if (! empty($uri)) {
+        if ('' !== $uri) {
             $this->parseUri($uri);
         }
     }
@@ -147,12 +147,12 @@ class Uri implements UriInterface
      */
     public function getAuthority()
     {
-        if (empty($this->host)) {
+        if ('' === $this->host) {
             return '';
         }
 
         $authority = $this->host;
-        if (! empty($this->userInfo)) {
+        if ('' !== $this->userInfo) {
             $authority = $this->userInfo . '@' . $authority;
         }
 
@@ -476,27 +476,26 @@ class Uri implements UriInterface
     {
         $uri = '';
 
-        if (! empty($scheme)) {
+        if ('' !== $scheme) {
             $uri .= sprintf('%s:', $scheme);
         }
 
-        if (! empty($authority)) {
+        if ('' !== $authority) {
             $uri .= '//' . $authority;
         }
 
-        if ($path) {
-            if (empty($path) || '/' !== substr($path, 0, 1)) {
-                $path = '/' . $path;
-            }
-
-            $uri .= $path;
+        if ('' !== $path && '/' !== substr($path, 0, 1)) {
+            $path = '/' . $path;
         }
 
-        if ($query) {
+        $uri .= $path;
+
+
+        if ('' !== $query) {
             $uri .= sprintf('?%s', $query);
         }
 
-        if ($fragment) {
+        if ('' !== $fragment) {
             $uri .= sprintf('#%s', $fragment);
         }
 
@@ -513,14 +512,11 @@ class Uri implements UriInterface
      */
     private function isNonStandardPort($scheme, $host, $port)
     {
-        if (! $scheme) {
-            if ($host && ! $port) {
-                return false;
-            }
-            return true;
+        if ('' === $scheme) {
+            return '' === $host || null !== $port;
         }
 
-        if (! $host || ! $port) {
+        if ('' === $host || null === $port) {
             return false;
         }
 
@@ -539,7 +535,7 @@ class Uri implements UriInterface
         $scheme = strtolower($scheme);
         $scheme = preg_replace('#:(//)?$#', '', $scheme);
 
-        if (empty($scheme)) {
+        if ('' === $scheme) {
             return '';
         }
 
@@ -585,7 +581,7 @@ class Uri implements UriInterface
             $path
         );
 
-        if (empty($path)) {
+        if ('' === $path) {
             // No path
             return $path;
         }
@@ -609,7 +605,7 @@ class Uri implements UriInterface
      */
     private function filterQuery($query)
     {
-        if (! empty($query) && strpos($query, '?') === 0) {
+        if ('' !== $query && strpos($query, '?') === 0) {
             $query = substr($query, 1);
         }
 
@@ -653,7 +649,7 @@ class Uri implements UriInterface
      */
     private function filterFragment($fragment)
     {
-        if (! empty($fragment) && strpos($fragment, '#') === 0) {
+        if ('' !== $fragment && strpos($fragment, '#') === 0) {
             $fragment = '%23' . substr($fragment, 1);
         }
 

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -689,4 +689,12 @@ class UriTest extends TestCase
         $uri = (new Uri())->withHost('NEW-HOST.COM');
         $this->assertSame('new-host.com', $uri->getHost());
     }
+
+
+    public function testUriDistinguishZeroFromEmptyString()
+    {
+        $expected = 'https://0:0@0:1/0?0#0';
+        $uri = new Uri($expected);
+        $this->assertSame($expected, (string) $uri);
+    }
 }


### PR DESCRIPTION
This PR resolves the following bug in the `Uri` class:

```php
<?php

use Zend\Diactoros\Uri;
$uri = new Uri('https://0:0@0:1/0?0#0'); // display https:/0'
// expected 'https://0:0@0:1/0?0#0'
```
All string comparison are made more strict now.

Maybe other PRs may look and fix this issue in other classes as well.
