### PR TITLE
Do not allow an invalid HTTP method for requests

### DIFF
--- a/src/Request/Serializer.php
+++ b/src/Request/Serializer.php
@@ -80,9 +80,6 @@ final class Serializer extends AbstractSerializer
     public static function toString(RequestInterface $request)
     {
         $httpMethod = $request->getMethod();
-        if (empty($httpMethod)) {
-            throw new UnexpectedValueException('Object can not be serialized because HTTP method is empty');
-        }
         $headers = self::serializeHeaders($request->getHeaders());
         $body    = (string) $request->getBody();
         $format  = '%s %s HTTP/%s%s%s';

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -37,7 +37,7 @@ trait RequestTrait
     /**
      * @var string
      */
-    private $method = '';
+    private $method = 'GET';
 
     /**
      * The request-target, if it has been provided or calculated.
@@ -64,9 +64,10 @@ trait RequestTrait
      */
     private function initialize($uri = null, $method = null, $body = 'php://memory', array $headers = [])
     {
-        $this->validateMethod($method);
+        if ($method !== null) {
+            $this->setMethod($method);
+        }
 
-        $this->method = $method ?: '';
         $this->uri    = $this->createUri($uri);
         $this->stream = $this->getStream($body, 'wb+');
 
@@ -204,9 +205,8 @@ trait RequestTrait
      */
     public function withMethod($method)
     {
-        $this->validateMethod($method);
         $new = clone $this;
-        $new->method = $method;
+        $new->setMethod($method);
         return $new;
     }
 
@@ -284,21 +284,17 @@ trait RequestTrait
     }
 
     /**
-     * Validate the HTTP method
+     * Set and validate the HTTP method
      *
-     * @param null|string $method
+     * @param string $method
      * @throws InvalidArgumentException on invalid HTTP method.
      */
-    private function validateMethod($method)
+    private function setMethod($method)
     {
-        if (null === $method) {
-            return;
-        }
-
         if (! is_string($method)) {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported HTTP method; must be a string, received %s',
-                (is_object($method) ? get_class($method) : gettype($method))
+                is_object($method) ? get_class($method) : gettype($method)
             ));
         }
 
@@ -308,6 +304,7 @@ trait RequestTrait
                 $method
             ));
         }
+        $this->method = $method;
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -226,42 +226,6 @@ class ServerRequest implements ServerRequestInterface
     }
 
     /**
-     * Proxy to receive the request method.
-     *
-     * This overrides the parent functionality to ensure the method is never
-     * empty; if no method is present, it returns 'GET'.
-     *
-     * @return string
-     */
-    public function getMethod()
-    {
-        if (empty($this->method)) {
-            return 'GET';
-        }
-        return $this->method;
-    }
-
-    /**
-     * Set the request method.
-     *
-     * Unlike the regular Request implementation, the server-side
-     * normalizes the method to uppercase to ensure consistency
-     * and make checking the method simpler.
-     *
-     * This methods returns a new instance.
-     *
-     * @param string $method
-     * @return self
-     */
-    public function withMethod($method)
-    {
-        $this->validateMethod($method);
-        $new = clone $this;
-        $new->method = $method;
-        return $new;
-    }
-
-    /**
      * Recursively validate the structure in an uploaded files array.
      *
      * @param array $uploadedFiles

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -337,14 +337,4 @@ class SerializerTest extends TestCase
 
         $this->assertInstanceOf(RelativeStream::class, $stream->getBody());
     }
-
-    public function testToStringRaisesExceptionOnEmptyMethod()
-    {
-        $request = (new Request())
-            ->withUri(new Uri('http://example.com/foo/bar?baz=bat'));
-
-        $this->expectException(UnexpectedValueException::class);
-
-        Serializer::toString($request);
-    }
 }

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -26,16 +26,33 @@ class RequestTest extends TestCase
         $this->request = new Request();
     }
 
-    public function testMethodIsEmptyByDefault()
+    public function testMethodIsGetByDefault()
     {
-        $this->assertSame('', $this->request->getMethod());
+        $this->assertSame('GET', $this->request->getMethod());
     }
 
     public function testMethodMutatorReturnsCloneWithChangedMethod()
     {
-        $request = $this->request->withMethod('GET');
+        $request = $this->request->withMethod('POST');
         $this->assertNotSame($this->request, $request);
-        $this->assertSame('GET', $request->getMethod());
+        $this->assertEquals('POST', $request->getMethod());
+    }
+
+    public function invalidMethod()
+    {
+        return [
+            [null],
+            [''],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidMethod
+     */
+    public function testWithInvalidMethod($method)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->request->withMethod($method);
     }
 
     public function testReturnsUnpopulatedUriByDefault()


### PR DESCRIPTION
This patch rebases and fixes the patch introduced with #162.

Internally, it modifies how the `RequestTrait` works to ensure that the HTTP method is _always_ valid; this allows removal of duplicated code in the `ServerRequest`, as well as a conditional and exception from the request serializer.

Considering PSR-17 _requires_ an HTTP method to its various request factories, this brings Diactoros in line with that proposed spec.