### PR TITLE
Removes deprecated functionality from ServerRequestFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
+- [#308](https://github.com/zendframework/zend-diactoros/pull/308) removes the following methods from the `ServerRequestFactory` class:
+  - `normalizeServer()` (use `Zend\Diactoros\normalizeServer()` instead)
+  - `marshalHeaders()` (use `Zend\Diactoros\marshalHeadersFromSapi()` instead)
+  - `marshalUriFromServer()` (use `Zend\Diactoros\marshalUriFromSapi()` instead)
+  - `marshalRequestUri()` (use `Uri::getPath()` from the `Uri` instance returned by `marshalUriFromSapi()` instead)
+  - `marshalHostAndPortFromHeaders()` (use `Uri::getHost()` and `Uri::getPort()` from the `Uri` instances returned by `marshalUriFromSapi()` instead)
+  - `stripQueryString()` (use `explode("?", $path, 2)[0]` instead)
+  - `normalizeFiles()` (use `Zend\Diactoros\normalizeUploadedFiles()` instead)
+
 - [#295](https://github.com/zendframework/zend-diactoros/pull/295) removes `Zend\Diactoros\Server`. You can use the `RequestHandlerRunner` class from
   [zendframework/zend-httphandlerrunner](https://docs.zendframework.com/zend-httphandlerrunner) to provide these capabilities instead.
 

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -1,26 +1,14 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Diactoros;
 
-use InvalidArgumentException;
-use Psr\Http\Message\UploadedFileInterface;
-use stdClass;
-use UnexpectedValueException;
-
-use function array_change_key_case;
 use function array_key_exists;
-use function explode;
-use function implode;
-use function is_array;
 use function is_callable;
-use function strtolower;
-
-use const CASE_LOWER;
 
 /**
  * Class for marshaling a request object from the current PHP environment.
@@ -55,7 +43,6 @@ abstract class ServerRequestFactory
      * @param array $cookies $_COOKIE superglobal
      * @param array $files $_FILES superglobal
      * @return ServerRequest
-     * @throws InvalidArgumentException for invalid file values
      */
     public static function fromGlobals(
         array $server = null,
@@ -87,154 +74,5 @@ abstract class ServerRequestFactory
             $body ?: $_POST,
             marshalProtocolVersionFromSapi($server)
         );
-    }
-
-    /**
-     * Access a value in an array, returning a default value if not found
-     *
-     * @deprecated since 1.8.0; no longer used internally.
-     * @param string $key
-     * @param array $values
-     * @param mixed $default
-     * @return mixed
-     */
-    public static function get($key, array $values, $default = null)
-    {
-        if (array_key_exists($key, $values)) {
-            return $values[$key];
-        }
-
-        return $default;
-    }
-
-    /**
-     * Search for a header value.
-     *
-     * Does a case-insensitive search for a matching header.
-     *
-     * If found, it is returned as a string, using comma concatenation.
-     *
-     * If not, the $default is returned.
-     *
-     * @deprecated since 1.8.0; no longer used internally.
-     * @param string $header
-     * @param array $headers
-     * @param mixed $default
-     * @return string
-     */
-    public static function getHeader($header, array $headers, $default = null)
-    {
-        $header  = strtolower($name);
-        $headers = array_change_key_case($headers, CASE_LOWER);
-        if (array_key_exists($header, $headers)) {
-            $value = is_array($headers[$header]) ? implode(', ', $headers[$header]) : $headers[$header];
-            return $value;
-        }
-
-        return $default;
-    }
-
-    /**
-     * Marshal the $_SERVER array
-     *
-     * Pre-processes and returns the $_SERVER superglobal.
-     *
-     * @deprected since 1.8.0; use Zend\Diactoros\normalizeServer() instead.
-     * @param array $server
-     * @return array
-     */
-    public static function normalizeServer(array $server)
-    {
-        return normalizeServer(
-            $server ?: $_SERVER,
-            is_callable(self::$apacheRequestHeaders) ? self::$apacheRequestHeaders : null
-        );
-    }
-
-    /**
-     * Normalize uploaded files
-     *
-     * Transforms each value into an UploadedFileInterface instance, and ensures
-     * that nested arrays are normalized.
-     *
-     * @deprecated since 1.8.0; use \Zend\Diactoros\normalizeUploadedFiles instead.
-     * @param array $files
-     * @return array
-     * @throws InvalidArgumentException for unrecognized values
-     */
-    public static function normalizeFiles(array $files)
-    {
-        return normalizeUploadedFiles($files);
-    }
-
-    /**
-     * Marshal headers from $_SERVER
-     *
-     * @deprecated since 1.8.0; use Zend\Diactoros\marshalHeadersFromSapi().
-     * @param array $server
-     * @return array
-     */
-    public static function marshalHeaders(array $server)
-    {
-        return marshalHeadersFromSapi($server);
-    }
-
-    /**
-     * Marshal the URI from the $_SERVER array and headers
-     *
-     * @deprecated since 1.8.0; use Zend\Diactoros\marshalUriFromSapi() instead.
-     * @param array $server
-     * @param array $headers
-     * @return Uri
-     */
-    public static function marshalUriFromServer(array $server, array $headers)
-    {
-        return marshalUriFromSapi($server, $headers);
-    }
-
-    /**
-     * Marshal the host and port from HTTP headers and/or the PHP environment
-     *
-     * @deprecated since 1.8.0; use Zend\Diactoros\marshalUriFromSapi() instead,
-     *     and pull the host and port from the Uri instance that function
-     *     returns.
-     * @param stdClass $accumulator
-     * @param array $server
-     * @param array $headers
-     */
-    public static function marshalHostAndPortFromHeaders(stdClass $accumulator, array $server, array $headers)
-    {
-        $uri = marshalUriFromSapi($server, $headers);
-        $accumulator->host = $uri->getHost();
-        $accumulator->port = $uri->getPort();
-    }
-
-    /**
-     * Detect the base URI for the request
-     *
-     * Looks at a variety of criteria in order to attempt to autodetect a base
-     * URI, including rewrite URIs, proxy URIs, etc.
-     *
-     * @deprecated since 1.8.0; use Zend\Diactoros\marshalUriFromSapi() instead,
-     *     and pull the path from the Uri instance that function returns.
-     * @param array $server
-     * @return string
-     */
-    public static function marshalRequestUri(array $server)
-    {
-        $uri = marshalUriFromSapi($server, []);
-        return $uri->getPath();
-    }
-
-    /**
-     * Strip the query string from a path
-     *
-     * @deprecated since 1.8.0; no longer used internally.
-     * @param mixed $path
-     * @return string
-     */
-    public static function stripQueryString($path)
-    {
-        return explode('?', $path, 2)[0];
     }
 }

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -24,33 +24,6 @@ use function Zend\Diactoros\normalizeUploadedFiles;
 
 class ServerRequestFactoryTest extends TestCase
 {
-    public function testGetWillReturnValueIfPresentInArray()
-    {
-        $array = [
-            'foo' => 'bar',
-            'bar' => '',
-            'baz' => null,
-        ];
-
-        foreach ($array as $key => $value) {
-            $this->assertSame($value, ServerRequestFactory::get($key, $array));
-        }
-    }
-
-    public function testGetWillReturnDefaultValueIfKeyIsNotInArray()
-    {
-        $try   = [ 'foo', 'bar', 'baz' ];
-        $array = [
-            'quz'  => true,
-            'quuz' => true,
-        ];
-        $default = 'BAT';
-
-        foreach ($try as $key) {
-            $this->assertSame($default, ServerRequestFactory::get($key, $array, $default));
-        }
-    }
-
     public function testReturnsServerValueUnchangedIfHttpAuthorizationHeaderIsPresent()
     {
         $server = [
@@ -100,18 +73,6 @@ class ServerRequestFactoryTest extends TestCase
         ];
 
         $this->assertEquals($expected, marshalHeadersFromSapi($server));
-    }
-
-    public function testStripQueryStringReturnsUnchangedStringIfNoQueryStringDetected()
-    {
-        $path = '/foo/bar';
-        $this->assertSame($path, ServerRequestFactory::stripQueryString($path));
-    }
-
-    public function testStripQueryStringReturnsNormalizedPathWhenQueryStringDetected()
-    {
-        $path = '/foo/bar?foo=bar';
-        $this->assertSame('/foo/bar', ServerRequestFactory::stripQueryString($path));
     }
 
     public function testMarshalRequestUriUsesIISUnencodedUrlValueIfPresentAndUrlWasRewritten()


### PR DESCRIPTION
Following on #307, this patch removes functionality deprecated for the 1.8 release within `ServerRequestFactory`. This includes all private methods, but also the following public methods:

- `normalizeServer()`
- `marshalHeaders()`
- `marshalUriFromServer()`
- `marshalRequestUri()`
- `marshalHostAndPortFromHeaders()`
- `stripQuerySTring()`
- `normalizeFiles()`