### PR TITLE
#311 - Update NormalizeUploadedFiles to handle multi-dimension recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.8.1 - TBD
+## 1.8.1 - 2018-07-09
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#312](https://github.com/zendframework/zend-diactoros/pull/312) fixes how the `normalizeUploadedFiles()` utility function handles nested trees of
+  uploaded files, ensuring it detects them properly.
 
 ## 1.8.0 - 2018-06-27
 

--- a/src/functions/normalize_uploaded_files.php
+++ b/src/functions/normalize_uploaded_files.php
@@ -25,6 +25,8 @@ use function is_array;
 function normalizeUploadedFiles(array $files)
 {
     /**
+     * Traverse a nested tree of uploaded file specifications.
+     *
      * @param string[]|array[] $tmpNameTree
      * @param int[]|array[] $sizeTree
      * @param int[]|array[] $errorTree

--- a/src/functions/normalize_uploaded_files.php
+++ b/src/functions/normalize_uploaded_files.php
@@ -25,6 +25,45 @@ use function is_array;
 function normalizeUploadedFiles(array $files)
 {
     /**
+     * @param string[]|array[] $tmpNameTree
+     * @param int[]|array[] $sizeTree
+     * @param int[]|array[] $errorTree
+     * @param string[]|array[]|null $nameTree
+     * @param string[]|array[]|null $typeTree
+     * @return UploadedFile[]|array[]
+     */
+    $recursiveNormalize = function (
+        array $tmpNameTree,
+        array $sizeTree,
+        array $errorTree,
+        array $nameTree = null,
+        array $typeTree = null
+    ) use (&$recursiveNormalize) {
+        $normalized = [];
+        foreach ($tmpNameTree as $key => $value) {
+            if (is_array($value)) {
+                // Traverse
+                $normalized[$key] = $recursiveNormalize(
+                    $tmpNameTree[$key],
+                    $sizeTree[$key],
+                    $errorTree[$key],
+                    $nameTree[$key] ?? null,
+                    $typeTree[$key] ?? null
+                );
+                continue;
+            }
+            $normalized[$key] = createUploadedFile([
+                'tmp_name' => $tmpNameTree[$key],
+                'size' => $sizeTree[$key],
+                'error' => $errorTree[$key],
+                'name' => $nameTree[$key] ?? null,
+                'type' => $typeTree[$key] ?? null
+            ]);
+        }
+        return $normalized;
+    };
+
+    /**
      * Normalize an array of file specifications.
      *
      * Loops through all nested files (as determined by receiving an array to the
@@ -38,7 +77,7 @@ function normalizeUploadedFiles(array $files)
      * @param array $files
      * @return UploadedFile[]
      */
-    $normalizeUploadedFileSpecification = function (array $files = []) {
+    $normalizeUploadedFileSpecification = function (array $files = []) use (&$recursiveNormalize) {
         if (! isset($files['tmp_name']) || ! is_array($files['tmp_name'])
             || ! isset($files['size']) || ! is_array($files['size'])
             || ! isset($files['error']) || ! is_array($files['error'])
@@ -51,19 +90,13 @@ function normalizeUploadedFiles(array $files)
             ));
         }
 
-
-        $normalized = [];
-        foreach (array_keys($files['tmp_name']) as $key) {
-            $spec = [
-                'tmp_name' => $files['tmp_name'][$key],
-                'size'     => $files['size'][$key],
-                'error'    => $files['error'][$key],
-                'name'     => isset($files['name'][$key]) ? $files['name'][$key] : null,
-                'type'     => isset($files['type'][$key]) ? $files['type'][$key] : null,
-            ];
-            $normalized[$key] = createUploadedFile($spec);
-        }
-        return $normalized;
+        return $recursiveNormalize(
+            $files['tmp_name'],
+            $files['size'],
+            $files['error'],
+            $files['name'] ?? null,
+            $files['type'] ?? null
+        );
     };
 
     $normalized = [];

--- a/src/functions/normalize_uploaded_files.php
+++ b/src/functions/normalize_uploaded_files.php
@@ -47,8 +47,8 @@ function normalizeUploadedFiles(array $files)
                     $tmpNameTree[$key],
                     $sizeTree[$key],
                     $errorTree[$key],
-                    $nameTree[$key] ?? null,
-                    $typeTree[$key] ?? null
+                    isset($nameTree[$key]) ? $nameTree[$key] : null,
+                    isset($typeTree[$key]) ? $typeTree[$key] : null
                 );
                 continue;
             }
@@ -56,8 +56,8 @@ function normalizeUploadedFiles(array $files)
                 'tmp_name' => $tmpNameTree[$key],
                 'size' => $sizeTree[$key],
                 'error' => $errorTree[$key],
-                'name' => $nameTree[$key] ?? null,
-                'type' => $typeTree[$key] ?? null
+                'name' => isset($nameTree[$key]) ? $nameTree[$key] : null,
+                'type' => isset($typeTree[$key]) ? $typeTree[$key] : null
             ]);
         }
         return $normalized;
@@ -94,8 +94,8 @@ function normalizeUploadedFiles(array $files)
             $files['tmp_name'],
             $files['size'],
             $files['error'],
-            $files['name'] ?? null,
-            $files['type'] ?? null
+            isset($files['name']) ? $files['name'] : null,
+            isset($files['type']) ? $files['type'] : null
         );
     };
 

--- a/test/functions/NormalizeUploadedFilesTest.php
+++ b/test/functions/NormalizeUploadedFilesTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
@@ -9,11 +9,12 @@ namespace ZendTest\Diactoros;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UploadedFileInterface;
+
 use function Zend\Diactoros\normalizeUploadedFiles;
 
 class NormalizeUploadedFilesTest extends TestCase
 {
-    public function testFlatFile()
+    public function testCreatesUploadedFileFromFlatFileSpecification()
     {
         $files = [
             'avatar' => [
@@ -32,7 +33,7 @@ class NormalizeUploadedFilesTest extends TestCase
         $this->assertEquals('my-avatar.png', $normalised['avatar']->getClientFilename());
     }
 
-    public function testNestedFile()
+    public function testTraversesNestedFileSpecificationToExtractUploadedFile()
     {
         $files = [
             'my-form' => [
@@ -54,7 +55,7 @@ class NormalizeUploadedFilesTest extends TestCase
         $this->assertEquals('my-avatar.png', $normalised['my-form']['details']['avatar']->getClientFilename());
     }
 
-    public function testNumericIndexedFiles()
+    public function testTraversesNestedFileSpecificationContainingNumericIndicesToExtractUploadedFiles()
     {
         $files = [
             'my-form' => [
@@ -99,9 +100,10 @@ class NormalizeUploadedFilesTest extends TestCase
     }
 
     /**
-     * This case covers upfront numeric index which moves the tmp_name/size/etc fields further up the array tree
+     * This case covers upfront numeric index which moves the tmp_name/size/etc
+     * fields further up the array tree
      */
-    public function testNumericFirstIndexedFiles()
+    public function testTraversesDenormalizedNestedTreeOfIndicesToExtractUploadedFiles()
     {
         $files = [
             'slide-shows' => [

--- a/test/functions/NormalizeUploadedFilesTest.php
+++ b/test/functions/NormalizeUploadedFilesTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UploadedFileInterface;
+use function Zend\Diactoros\normalizeUploadedFiles;
+
+class NormalizeUploadedFilesTest extends TestCase
+{
+    public function testFlatFile()
+    {
+        $files = [
+            'avatar' => [
+                'tmp_name' => 'phpUxcOty',
+                'name' => 'my-avatar.png',
+                'size' => 90996,
+                'type' => 'image/png',
+                'error' => 0,
+            ],
+        ];
+
+        $normalised = normalizeUploadedFiles($files);
+
+        $this->assertCount(1, $normalised);
+        $this->assertInstanceOf(UploadedFileInterface::class, $normalised['avatar']);
+        $this->assertEquals('my-avatar.png', $normalised['avatar']->getClientFilename());
+    }
+
+    public function testNestedFile()
+    {
+        $files = [
+            'my-form' => [
+                'details' => [
+                    'avatar' => [
+                        'tmp_name' => 'phpUxcOty',
+                        'name' => 'my-avatar.png',
+                        'size' => 90996,
+                        'type' => 'image/png',
+                        'error' => 0,
+                    ],
+                ],
+            ],
+        ];
+
+        $normalised = normalizeUploadedFiles($files);
+
+        $this->assertCount(1, $normalised);
+        $this->assertEquals('my-avatar.png', $normalised['my-form']['details']['avatar']->getClientFilename());
+    }
+
+    public function testNumericIndexedFiles()
+    {
+        $files = [
+            'my-form' => [
+                'details' => [
+                    'avatars' => [
+                        'tmp_name' => [
+                            0 => 'abc123',
+                            1 => 'duck123',
+                            2 => 'goose123',
+                        ],
+                        'name' => [
+                            0 => 'file1.txt',
+                            1 => 'file2.txt',
+                            2 => 'file3.txt',
+                        ],
+                        'size' => [
+                            0 => 100,
+                            1 => 240,
+                            2 => 750,
+                        ],
+                        'type' => [
+                            0 => 'plain/txt',
+                            1 => 'image/jpg',
+                            2 => 'image/png',
+                        ],
+                        'error' => [
+                            0 => 0,
+                            1 => 0,
+                            2 => 0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $normalised = normalizeUploadedFiles($files);
+
+        $this->assertCount(3, $normalised['my-form']['details']['avatars']);
+        $this->assertEquals('file1.txt', $normalised['my-form']['details']['avatars'][0]->getClientFilename());
+        $this->assertEquals('file2.txt', $normalised['my-form']['details']['avatars'][1]->getClientFilename());
+        $this->assertEquals('file3.txt', $normalised['my-form']['details']['avatars'][2]->getClientFilename());
+    }
+
+    /**
+     * This case covers upfront numeric index which moves the tmp_name/size/etc fields further up the array tree
+     */
+    public function testNumericFirstIndexedFiles()
+    {
+        $files = [
+            'slide-shows' => [
+                'tmp_name' => [
+                    // Note: Nesting *under* tmp_name/etc
+                    0 => [
+                        'slides' => [
+                            0 => '/tmp/phpYzdqkD',
+                            1 => '/tmp/phpYzdfgh',
+                        ],
+                    ],
+                ],
+                'error' => [
+                    0 => [
+                        'slides' => [
+                            0 => 0,
+                            1 => 0,
+                        ],
+                    ],
+                ],
+                'name' => [
+                    0 => [
+                        'slides' => [
+                            0 => 'foo.txt',
+                            1 => 'bar.txt',
+                        ],
+                    ],
+                ],
+                'size' => [
+                    0 => [
+                        'slides' => [
+                            0 => 123,
+                            1 => 200,
+                        ],
+                    ],
+                ],
+                'type' => [
+                    0 => [
+                        'slides' => [
+                            0 => 'text/plain',
+                            1 => 'text/plain',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $normalised = normalizeUploadedFiles($files);
+
+        $this->assertCount(2, $normalised['slide-shows'][0]['slides']);
+        $this->assertEquals('foo.txt', $normalised['slide-shows'][0]['slides'][0]->getClientFilename());
+        $this->assertEquals('bar.txt', $normalised['slide-shows'][0]['slides'][1]->getClientFilename());
+    }
+}


### PR DESCRIPTION
To address https://github.com/zendframework/zend-diactoros/issues/311 (Some/All?) SAPI's index the `tmp_name` etc common fields from the point that a numerically indexed array is encountered which is causing Diactoros to fail fatally with form uploads that use multi-dimensional named fields containing a numeric index (as well as not converting all leaf nodes for deeper hierarchies of file upload field names).

This change updates normalizeUploadedFiles to be recursive and introduces several tests to verify the behaviour matches the PSR-7 spec + the scenario not mentioned by the spec.

Note: given the number of "private" functions being encapsulated in this larger function it may be worth considering converting this to an object instead especially as the recursion and lack of hoisting makes declaration order of the "private" functions non-idiomatic for most PHP engineers. I avoided significant changes here given it's just a fix, but food for thought!

Also, first time I've contributed to this project: please let me know if I've incorrectly interpreted the contrib. standards and I need to fix anything 😃 

@pascalzajac @serroba FYI
