### PR TITLE
Updates reason phrase for 425 response status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#313](https://github.com/zendframework/zend-diactoros/pull/313) changes the reason phrase associated with the status code 425
+  to "Too Early", corresponding to a new definition of the code as specified by the IANA.
 
 ### Deprecated
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -87,7 +87,7 @@ class Response implements ResponseInterface
         422 => 'Unprocessable Entity',
         423 => 'Locked',
         424 => 'Failed Dependency',
-        425 => 'Unordered Collection',
+        425 => 'Too Early',
         426 => 'Upgrade Required',
         428 => 'Precondition Required',
         429 => 'Too Many Requests',


### PR DESCRIPTION
The IANA HTTP status codes list was updated on 2018-07-02 to reflect a new IETF draft, draft-ietf-httpbis-replay-04, which details a header that may be used to indicate that an "early data" request may not yet be accepted, as no TLS handshake has been previously made, and that the request myust be retried after receiving the 425 response.

Without this change, tests fail on all platforms as the hard-coded reason phrase in `Zend\Diactoros\Response` references an early, non-standards-track usage of the status code.