### PR TITLE
Workaround PHP bug #63206 in Stream::setStream method

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -330,8 +330,12 @@ class Stream implements StreamInterface
 
         if (is_string($stream)) {
             set_error_handler(function ($e) use (&$error) {
+                if ($e !== E_WARNING) {
+                    return;
+                }
+
                 $error = $e;
-            }, E_WARNING);
+            });
             $resource = fopen($stream, $mode);
             restore_error_handler();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This PR fixes #298 by removing the usage of the second argument of the `set_error_handler` function and moves the check of the level of the raised error inside the error handler callback.