### PR TITLE
Ensure checks for HTTPS scheme are case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#318](https://github.com/zendframework/zend-diactoros/pull/318) fixes the logic for discovering whether an HTTPS scheme is in play
+  to be case insensitive when comparing header and SAPI values, ensuring no
+  false negative lookups occur.
+
 - [#314](https://github.com/zendframework/zend-diactoros/pull/314) modifies error handling around opening a file resource within
   `Zend\Diactoros\Stream::setStream()` to no longer use the second argument to
   `set_error_handler()`, and instead check the error type in the handler itself;

--- a/src/functions/marshal_uri_from_sapi.php
+++ b/src/functions/marshal_uri_from_sapi.php
@@ -172,9 +172,15 @@ function marshalUriFromSapi(array $server, array $headers)
 
     // URI scheme
     $scheme = 'http';
-    $https  = array_key_exists('HTTPS', $server) ? $server['HTTPS'] : false;
-    if (($https && 'off' !== $https)
-        || $getHeaderFromArray('x-forwarded-proto', $headers, false) === 'https'
+    if (array_key_exists('HTTPS', $server)) {
+        $https = $server['HTTPS'];
+    } elseif (array_key_exists('https', $server)) {
+        $https = $server['https'];
+    } else {
+        $https = false;
+    }
+    if (($https && 'off' !== strtolower($https))
+        || strtolower($getHeaderFromArray('x-forwarded-proto', $headers, false)) === 'https'
     ) {
         $scheme = 'https';
     }


### PR DESCRIPTION
- Checks for either `HTTPS` or `https` in the `$server` array.
- Does a case-insensitive check against the value discovered to see if it is equivalent to "off".
- Does a case-insenstivie check against the value of the `X-Forwarded-Proto` header to see if it is equivalent to "https".

Fixes #317