### PR TITLE
Implement PSR-17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.tmp/
 doc/html/
 vendor/
 zf-mkdoc-theme/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
         - DEPS=locked
         - CS_CHECK=true
         - TEST_COVERAGE=true
-        - INTEGRATION_DEPS="http-interop/http-factory-diactoros"
     - php: 7.1
       env:
         - DEPS=latest
@@ -33,10 +32,9 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-    - php: 7.2
-      name: Integration tests
+    - php: nightly
       env:
-        - INTEGRATION_DEPS="http-interop/http-factory-diactoros"
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
@@ -45,7 +43,6 @@ install:
   - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $INTEGRATION_DEPS != '' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $INTEGRATION_DEPS ; fi
   - stty cols 120 && composer show
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#326](https://github.com/zendframework/zend-diactoros/pull/326) adds [PSR-17](https://www.php-fig.org/psr/psr-17/) HTTP Message Factory implementations, including:
+
+  - `Zend\Diactoros\RequestFactory`
+  - `Zend\Diactoros\ResponseFactory`
+  - `Zend\Diactoros\ServerRequestFactory`
+  - `Zend\Diactoros\StreamFactory`
+  - `Zend\Diactoros\UploadedFileFactory`
+  - `Zend\Diactoros\UriFactory`
+
+  These factories may be used to produce the associated instances; we encourage
+  users to rely on the PSR-17 factory interfaces to allow exchanging PSR-7
+  implementations within their applications.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -27,16 +27,19 @@
   },
   "require": {
     "php": "^7.1",
+    "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0"
   },
   "require-dev": {
     "ext-dom": "*",
     "ext-libxml": "*",
+    "http-interop/http-factory-tests": "^0.5.0",
     "php-http/psr7-integration-tests": "dev-master",
     "phpunit/phpunit": "^7.0.2",
     "zendframework/zend-coding-standard": "~1.0.0"
   },
   "provide": {
+    "psr/http-factory-implementation": "1.0",
     "psr/http-message-implementation": "1.0"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,60 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0727246a3cdf80b2bb87748aa12ec6b9",
+    "content-hash": "efa171d75259239d91bf4012edd5620e",
     "packages": [
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "378bfe27931ecc54ff824a20d6f6bfc303bbd04c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/378bfe27931ecc54ff824a20d6f6bfc303bbd04c",
+                "reference": "378bfe27931ecc54ff824a20d6f6bfc303bbd04c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2018-07-30T21:54:04+00:00"
+        },
         {
             "name": "psr/http-message",
             "version": "1.0.1",
@@ -111,6 +163,50 @@
                 "instantiate"
             ],
             "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "http-interop/http-factory-tests",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-factory-tests.git",
+                "reference": "3c6c62052daeb67ca7dc3e1ea1b72c0f0cc19070"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-factory-tests/zipball/3c6c62052daeb67ca7dc3e1ea1b72c0f0cc19070",
+                "reference": "3c6c62052daeb67ca7dc3e1ea1b72c0f0cc19070",
+                "shasum": ""
+            },
+            "require": {
+                "phpunit/phpunit": "^6.5 || ^7.0",
+                "psr/http-factory": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Factory\\": "test/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Unit tests for HTTP factories",
+            "keywords": [
+                "factory",
+                "http",
+                "psr-17",
+                "psr-7",
+                "test"
+            ],
+            "time": "2018-07-31T18:30:29+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/doc/book/factories.md
+++ b/doc/book/factories.md
@@ -1,0 +1,18 @@
+# HTTP Message Factories
+
+[PSR-17](https://www.php-fig.org/psr/psr-17/) defines factory interfaces for
+creating [PSR-7](https://www.php-fig.org/psr/psr-7/) instances. As of version
+2.0.0, Diactoros supplies implementations of each as follows:
+
+- `Zend\Diactoros\RequestFactory`
+- `Zend\Diactoros\ResponseFactory`
+- `Zend\Diactoros\ServerRequestFactory`
+- `Zend\Diactoros\StreamFactory`
+- `Zend\Diactoros\UploadedFileFactory`
+- `Zend\Diactoros\UriFactory`
+
+The `ServerRequestFactory` continues to define the static method
+`fromGlobals()`, but also serves as a PSR-17 implementation.
+
+These classes may be used as described in the specification document for the
+purpose of creating Diactoros instances that fulfill PSR-7 typehints.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ pages:
     - Installation: install.md
     - Usage: usage.md
     - Reference:
+        - Factories: factories.md
         - "Custom Responses": custom-responses.md
         - "Emitting Responses": emitting-responses.md
         - Serialization: serialization.md

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,9 @@
         <testsuite name="Zend\\Diactoros Tests">
             <directory>./test</directory>
         </testsuite>
+        <testsuite name="PSR-17 Integration Tests">
+            <directory>./vendor/http-interop/http-factory-tests/test</directory>
+        </testsuite>
     </testsuites>
 
     <filter>
@@ -12,11 +15,11 @@
     </filter>
 
     <php>
-        <const name="REQUEST_FACTORY" value="Http\Factory\Diactoros\RequestFactory"/>
-        <const name="RESPONSE_FACTORY" value="Http\Factory\Diactoros\ResponseFactory"/>
-        <const name="SERVER_REQUEST_FACTORY" value="Http\Factory\Diactoros\ServerRequestFactory"/>
-        <const name="STREAM_FACTORY" value="Http\Factory\Diactoros\StreamFactory"/>
-        <const name="UPLOADED_FILE_FACTORY" value="Http\Factory\Diactoros\UploadedFileFactory"/>
-        <const name="URI_FACTORY" value="Http\Factory\Diactoros\UriFactory"/>
+        <const name="REQUEST_FACTORY" value="Zend\Diactoros\RequestFactory"/>
+        <const name="RESPONSE_FACTORY" value="Zend\Diactoros\ResponseFactory"/>
+        <const name="SERVER_REQUEST_FACTORY" value="Zend\Diactoros\ServerRequestFactory"/>
+        <const name="STREAM_FACTORY" value="Zend\Diactoros\StreamFactory"/>
+        <const name="UPLOADED_FILE_FACTORY" value="Zend\Diactoros\UploadedFileFactory"/>
+        <const name="URI_FACTORY" value="Zend\Diactoros\UriFactory"/>
     </php>
 </phpunit>

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+
+class RequestFactory implements RequestFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createRequest(string $method, $uri) : RequestInterface
+    {
+        return new Request($uri, $method);
+    }
+}

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ResponseFactory implements ResponseFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createResponse(int $code = 200, string $reasonPhrase = '') : ResponseInterface
+    {
+        return (new Response())
+            ->withStatus($code, $reasonPhrase);
+    }
+}

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -7,6 +7,9 @@
 
 namespace Zend\Diactoros;
 
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
 use function array_key_exists;
 use function is_callable;
 
@@ -18,7 +21,7 @@ use function is_callable;
  * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
-abstract class ServerRequestFactory
+class ServerRequestFactory implements ServerRequestFactoryInterface
 {
     /**
      * Function to use to get apache request headers; present only to simplify mocking.
@@ -73,6 +76,21 @@ abstract class ServerRequestFactory
             $query ?: $_GET,
             $body ?: $_POST,
             marshalProtocolVersionFromSapi($server)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createServerRequest(string $method, $uri, array $serverParams = []) : ServerRequestInterface
+    {
+        $uploadedFiles = [];
+
+        return new ServerRequest(
+            $serverParams,
+            $uploadedFiles,
+            $uri,
+            $method
         );
     }
 }

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use InvalidArgumentException;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+use function fopen;
+use function fwrite;
+use function get_resource_type;
+use function is_resource;
+use function rewind;
+
+class StreamFactory implements StreamFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createStream(string $content = '') : StreamInterface
+    {
+        $resource = fopen('php://temp', 'r+');
+        fwrite($resource, $content);
+        rewind($resource);
+
+        return $this->createStreamFromResource($resource);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createStreamFromFile(string $file, string $mode = 'r') : StreamInterface
+    {
+        return new Stream($file, $mode);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createStreamFromResource($resource) : StreamInterface
+    {
+        if (! is_resource($resource) || 'stream' !== get_resource_type($resource)) {
+            throw new InvalidArgumentException(
+                'Invalid stream provided; must be a stream resource'
+            );
+        }
+        return new Stream($resource);
+    }
+}

--- a/src/UploadedFileFactory.php
+++ b/src/UploadedFileFactory.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+use const UPLOAD_ERR_OK;
+
+class UploadedFileFactory implements UploadedFileFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createUploadedFile(
+        StreamInterface $stream,
+        int $size = null,
+        int $error = UPLOAD_ERR_OK,
+        string $clientFilename = null,
+        string $clientMediaType = null
+    ) : UploadedFileInterface {
+        if ($size === null) {
+            $size = $stream->getSize();
+        }
+
+        return new UploadedFile($stream, $size, $error, $clientFilename, $clientMediaType);
+    }
+}

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Diactoros;
+
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
+
+class UriFactory implements UriFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createUri(string $uri = '') : UriInterface
+    {
+        return new Uri($uri);
+    }
+}

--- a/test/Integration/RequestTest.php
+++ b/test/Integration/RequestTest.php
@@ -7,9 +7,9 @@
 
 namespace ZendTest\Diactoros\Integration;
 
-use Http\Factory\Diactoros\RequestFactory;
 use Http\Psr7Test\RequestIntegrationTest;
 use Zend\Diactoros\Request;
+use Zend\Diactoros\RequestFactory;
 
 class RequestTest extends RequestIntegrationTest
 {

--- a/test/Integration/ResponseTest.php
+++ b/test/Integration/ResponseTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Diactoros\Integration;
 
-use Http\Factory\Diactoros\RequestFactory;
 use Http\Psr7Test\ResponseIntegrationTest;
+use Zend\Diactoros\RequestFactory;
 use Zend\Diactoros\Response;
 
 class ResponseTest extends ResponseIntegrationTest

--- a/test/Integration/ServerRequestTest.php
+++ b/test/Integration/ServerRequestTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Diactoros\Integration;
 
-use Http\Factory\Diactoros\RequestFactory;
 use Http\Psr7Test\ServerRequestIntegrationTest;
+use Zend\Diactoros\RequestFactory;
 use Zend\Diactoros\ServerRequest;
 
 class ServerRequestTest extends ServerRequestIntegrationTest

--- a/test/Integration/StreamTest.php
+++ b/test/Integration/StreamTest.php
@@ -7,9 +7,9 @@
 
 namespace ZendTest\Diactoros\Integration;
 
-use Http\Factory\Diactoros\RequestFactory;
 use Http\Psr7Test\StreamIntegrationTest;
 use Psr\Http\Message\StreamInterface;
+use Zend\Diactoros\RequestFactory;
 use Zend\Diactoros\Stream;
 
 class StreamTest extends StreamIntegrationTest

--- a/test/Integration/UploadedFileTest.php
+++ b/test/Integration/UploadedFileTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Diactoros\Integration;
 
-use Http\Factory\Diactoros\RequestFactory;
 use Http\Psr7Test\UploadedFileIntegrationTest;
+use Zend\Diactoros\RequestFactory;
 use Zend\Diactoros\Stream;
 use Zend\Diactoros\UploadedFile;
 

--- a/test/Integration/UriTest.php
+++ b/test/Integration/UriTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Diactoros\Integration;
 
-use Http\Factory\Diactoros\RequestFactory;
 use Http\Psr7Test\UriIntegrationTest;
+use Zend\Diactoros\RequestFactory;
 use Zend\Diactoros\Uri;
 
 class UriTest extends UriIntegrationTest

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -568,13 +568,4 @@ class ServerRequestFactoryTest extends TestCase
         $uri = marshalUriFromSapi($server, $headers);
         $this->assertSame('/requested/path', $uri->getPath());
     }
-
-    public function testGetHeader()
-    {
-        $headers = [
-            'Host' => 'example.com'
-        ];
-
-        $this->assertSame('example.com', ServerRequestFactory::getHeader('Host', $headers));
-    }
 }


### PR DESCRIPTION
This patch implements the PSR-17 interfaces, and tests them against the http-interop/http-factory-tests integration test suite.

As part of the change, we are also able to remove the additional integration test dependency when testing against the PSR-7 integration tests. Those tests rely on PSR-17 factories, which we now provide, and map within the `phpunit.xml.dist` file. As such, both PSR-7 and PSR-17 integration tests will run for every build target.

All PSR-17 implementations are alongside the PSR-7 classes they create.

Also adds php nightly build to matrix, to ensure we are prepared for PHP 7.3.