### PR TITLE
Declare strict_types and use STH/RTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#329](https://github.com/zendframework/zend-diactoros/pull/329) adds return type hints and scalar parameter type hints wherever possible.
+  The changes were done to help improve code quality, in part by reducing manual
+  type checking. If you are extending any classes, you may need to update your
+  signatures; check the signatures of the class(es) you are extending for changes.
+
 - [#162](https://github.com/zendframework/zend-diactoros/pull/162) modifies `Serializer\Request` such that it now no longer raises an `UnexpectedValueException` via its `toString()` method
   when an unexpected HTTP method is encountered; this can be done safely, as the value can never
   be invalid due to other changes in the same patch.

--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -5,6 +5,10 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
@@ -34,12 +38,10 @@ abstract class AbstractSerializer
      * Retrieves a line from the stream; a line is defined as a sequence of
      * characters ending in a CRLF sequence.
      *
-     * @param StreamInterface $stream
-     * @return string
      * @throws Exception\DeserializationException if the sequence contains a CR
      *     or LF in isolation, or ends in a CR.
      */
-    protected static function getLine(StreamInterface $stream)
+    protected static function getLine(StreamInterface $stream) : string
     {
         $line    = '';
         $crFound = false;
@@ -87,11 +89,9 @@ abstract class AbstractSerializer
      * - The first is an array of headers
      * - The second is a StreamInterface containing the body content
      *
-     * @param StreamInterface $stream
-     * @return array
      * @throws Exception\DeserializationException For invalid headers.
      */
-    protected static function splitStream(StreamInterface $stream)
+    protected static function splitStream(StreamInterface $stream) : array
     {
         $headers       = [];
         $currentHeader = false;
@@ -125,11 +125,8 @@ abstract class AbstractSerializer
 
     /**
      * Serialize headers to string values.
-     *
-     * @param array $headers
-     * @return string
      */
-    protected static function serializeHeaders(array $headers)
+    protected static function serializeHeaders(array $headers) : string
     {
         $lines = [];
         foreach ($headers as $header => $values) {
@@ -144,11 +141,8 @@ abstract class AbstractSerializer
 
     /**
      * Filter a header name to wordcase
-     *
-     * @param string $header
-     * @return string
      */
-    protected static function filterHeader($header)
+    protected static function filterHeader($header) : string
     {
         $filtered = str_replace('-', ' ', $header);
         $filtered = ucwords($filtered);

--- a/src/CallbackStream.php
+++ b/src/CallbackStream.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
@@ -35,7 +37,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString() : string
     {
         return $this->getContents();
     }
@@ -43,7 +45,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function close()
+    public function close() : void
     {
         $this->callback = null;
     }
@@ -51,7 +53,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function detach()
+    public function detach() : ?callable
     {
         $callback = $this->callback;
         $this->callback = null;
@@ -60,11 +62,8 @@ class CallbackStream implements StreamInterface
 
     /**
      * Attach a new callback to the instance.
-     *
-     * @param callable $callback
-     * @throws Exception\InvalidArgumentException for callable callback
      */
-    public function attach(callable $callback)
+    public function attach(callable $callback) : void
     {
         $this->callback = $callback;
     }
@@ -72,14 +71,15 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getSize()
+    public function getSize() : ?int
     {
+        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function tell()
+    public function tell() : int
     {
         throw Exception\UntellableStreamException::forCallbackStream();
     }
@@ -87,7 +87,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function eof()
+    public function eof() : bool
     {
         return empty($this->callback);
     }
@@ -95,7 +95,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function isSeekable()
+    public function isSeekable() : bool
     {
         return false;
     }
@@ -111,7 +111,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind() : void
     {
         throw Exception\UnrewindableStreamException::forCallbackStream();
     }
@@ -119,7 +119,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function isWritable()
+    public function isWritable() : bool
     {
         return false;
     }
@@ -127,7 +127,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function write($string)
+    public function write($string) : void
     {
         throw Exception\UnwritableStreamException::forCallbackStream();
     }
@@ -135,7 +135,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function isReadable()
+    public function isReadable() : bool
     {
         return false;
     }
@@ -143,7 +143,7 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function read($length)
+    public function read($length) : string
     {
         throw Exception\UnreadableStreamException::forCallbackStream();
     }
@@ -151,10 +151,11 @@ class CallbackStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getContents()
+    public function getContents() : string
     {
         $callback = $this->detach();
-        return $callback ? $callback() : '';
+        $contents = $callback ? $callback() : '';
+        return (string) $contents;
     }
 
     /**

--- a/src/Exception/DeserializationException.php
+++ b/src/Exception/DeserializationException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use Throwable;
@@ -24,12 +26,12 @@ class DeserializationException extends UnexpectedValueException implements Excep
 
     public static function forRequestFromArray(Throwable $previous) : self
     {
-        return new self('Cannot deserialize request', null, $previous);
+        return new self('Cannot deserialize request', $previous->getCode(), $previous);
     }
 
     public static function forResponseFromArray(Throwable $previous) : self
     {
-        return new self('Cannot deserialize resposne', null, $previous);
+        return new self('Cannot deserialize response', $previous->getCode(), $previous);
     }
 
     public static function forUnexpectedCarriageReturn() : self

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use Throwable;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/src/Exception/InvalidStreamPointerPositionException.php
+++ b/src/Exception/InvalidStreamPointerPositionException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/SerializationException.php
+++ b/src/Exception/SerializationException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use UnexpectedValueException;

--- a/src/Exception/UnreadableStreamException.php
+++ b/src/Exception/UnreadableStreamException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/UnrecognizedProtocolVersionException.php
+++ b/src/Exception/UnrecognizedProtocolVersionException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use UnexpectedValueException;

--- a/src/Exception/UnrewindableStreamException.php
+++ b/src/Exception/UnrewindableStreamException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/UnseekableStreamException.php
+++ b/src/Exception/UnseekableStreamException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/UntellableStreamException.php
+++ b/src/Exception/UntellableStreamException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/UnwritableStreamException.php
+++ b/src/Exception/UnwritableStreamException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/UploadedFileAlreadyMovedException.php
+++ b/src/Exception/UploadedFileAlreadyMovedException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/Exception/UploadedFileErrorException.php
+++ b/src/Exception/UploadedFileErrorException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Exception;
 
 use RuntimeException;

--- a/src/HeaderSecurity.php
+++ b/src/HeaderSecurity.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function get_class;
@@ -50,10 +52,8 @@ final class HeaderSecurity
      * lossy.
      *
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
-     * @param string $value
-     * @return string
      */
-    public static function filter($value)
+    public static function filter(string $value) : string
     {
         $value  = (string) $value;
         $length = strlen($value);
@@ -98,11 +98,10 @@ final class HeaderSecurity
      * tabs are allowed in values; header continuations MUST consist of
      * a single CRLF sequence followed by a space or horizontal tab.
      *
+     * @param string|int|float $value
      * @see http://en.wikipedia.org/wiki/HTTP_response_splitting
-     * @param string $value
-     * @return bool
      */
-    public static function isValid($value)
+    public static function isValid($value) : bool
     {
         $value  = (string) $value;
 
@@ -131,7 +130,7 @@ final class HeaderSecurity
     /**
      * Assert a header value is valid.
      *
-     * @param string $value
+     * @param mixed $value Value to be tested. This method asserts it is a string or number.
      * @throws Exception\InvalidArgumentException for invalid values
      */
     public static function assertValid($value)

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -5,8 +5,11 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 
 use function array_map;
@@ -60,7 +63,7 @@ trait MessageTrait
      *
      * @return string HTTP protocol version.
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion() : string
     {
         return $this->protocol;
     }
@@ -78,7 +81,7 @@ trait MessageTrait
      * @param string $version HTTP protocol version
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version) : MessageInterface
     {
         $this->validateProtocolVersion($version);
         $new = clone $this;
@@ -107,7 +110,7 @@ trait MessageTrait
      * @return array Returns an associative array of the message's headers. Each
      *     key MUST be a header name, and each value MUST be an array of strings.
      */
-    public function getHeaders()
+    public function getHeaders() : array
     {
         return $this->headers;
     }
@@ -120,7 +123,7 @@ trait MessageTrait
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($header)
+    public function hasHeader($header) : bool
     {
         return isset($this->headerNames[strtolower($header)]);
     }
@@ -139,7 +142,7 @@ trait MessageTrait
      *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
-    public function getHeader($header)
+    public function getHeader($header) : array
     {
         if (! $this->hasHeader($header)) {
             return [];
@@ -169,7 +172,7 @@ trait MessageTrait
      *    concatenated together using a comma. If the header does not appear in
      *    the message, this method MUST return an empty string.
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine($name) : string
     {
         $value = $this->getHeader($name);
         if (empty($value)) {
@@ -195,7 +198,7 @@ trait MessageTrait
      * @return static
      * @throws Exception\InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($header, $value)
+    public function withHeader($header, $value) : MessageInterface
     {
         $this->assertHeader($header);
 
@@ -231,7 +234,7 @@ trait MessageTrait
      * @return static
      * @throws Exception\InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader($header, $value) : MessageInterface
     {
         $this->assertHeader($header);
 
@@ -259,7 +262,7 @@ trait MessageTrait
      * @param string $header Case-insensitive header field name to remove.
      * @return static
      */
-    public function withoutHeader($header)
+    public function withoutHeader($header) : MessageInterface
     {
         if (! $this->hasHeader($header)) {
             return clone $this;
@@ -278,7 +281,7 @@ trait MessageTrait
      *
      * @return StreamInterface Returns the body as a stream.
      */
-    public function getBody()
+    public function getBody() : StreamInterface
     {
         return $this->stream;
     }
@@ -296,14 +299,14 @@ trait MessageTrait
      * @return static
      * @throws Exception\InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body) : MessageInterface
     {
         $new = clone $this;
         $new->stream = $body;
         return $new;
     }
 
-    private function getStream($stream, $modeIfNotInstance)
+    private function getStream($stream, string $modeIfNotInstance) : StreamInterface
     {
         if ($stream instanceof StreamInterface) {
             return $stream;
@@ -327,7 +330,7 @@ trait MessageTrait
      *
      * @param array $originalHeaders Headers to filter.
      */
-    private function setHeaders(array $originalHeaders)
+    private function setHeaders(array $originalHeaders) : void
     {
         $headerNames = $headers = [];
 
@@ -350,7 +353,7 @@ trait MessageTrait
      * @param string $version
      * @throws Exception\InvalidArgumentException on invalid HTTP protocol version
      */
-    private function validateProtocolVersion($version)
+    private function validateProtocolVersion($version) : void
     {
         if (empty($version)) {
             throw new Exception\InvalidArgumentException(
@@ -378,7 +381,7 @@ trait MessageTrait
      * @param mixed $values
      * @return string[]
      */
-    private function filterHeaderValue($values)
+    private function filterHeaderValue($values) : array
     {
         if (! is_array($values)) {
             $values = [$values];
@@ -405,7 +408,7 @@ trait MessageTrait
      *
      * @throws Exception\InvalidArgumentException
      */
-    private function assertHeader($name)
+    private function assertHeader($name) : void
     {
         HeaderSecurity::assertValidName($name);
     }

--- a/src/PhpInputStream.php
+++ b/src/PhpInputStream.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function stream_get_contents;
@@ -35,7 +37,7 @@ class PhpInputStream extends Stream
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString() : string
     {
         if ($this->reachedEof) {
             return $this->cache;
@@ -48,7 +50,7 @@ class PhpInputStream extends Stream
     /**
      * {@inheritdoc}
      */
-    public function isWritable()
+    public function isWritable() : bool
     {
         return false;
     }
@@ -56,7 +58,7 @@ class PhpInputStream extends Stream
     /**
      * {@inheritdoc}
      */
-    public function read($length)
+    public function read($length) : string
     {
         $content = parent::read($length);
         if (! $this->reachedEof) {
@@ -73,7 +75,7 @@ class PhpInputStream extends Stream
     /**
      * {@inheritdoc}
      */
-    public function getContents($maxLength = -1)
+    public function getContents($maxLength = -1) : string
     {
         if ($this->reachedEof) {
             return $this->cache;

--- a/src/RelativeStream.php
+++ b/src/RelativeStream.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
@@ -36,16 +38,16 @@ final class RelativeStream implements StreamInterface
      * @param StreamInterface $decoratedStream
      * @param int $offset
      */
-    public function __construct(StreamInterface $decoratedStream, $offset)
+    public function __construct(StreamInterface $decoratedStream, ?int $offset)
     {
         $this->decoratedStream = $decoratedStream;
-        $this->offset = (int)$offset;
+        $this->offset = (int) $offset;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString() : string
     {
         if ($this->isSeekable()) {
             $this->seek(0);
@@ -56,7 +58,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function close()
+    public function close() : void
     {
         $this->decoratedStream->close();
     }
@@ -72,7 +74,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getSize()
+    public function getSize() : int
     {
         return $this->decoratedStream->getSize() - $this->offset;
     }
@@ -80,7 +82,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function tell()
+    public function tell() : int
     {
         return $this->decoratedStream->tell() - $this->offset;
     }
@@ -88,7 +90,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function eof()
+    public function eof() : bool
     {
         return $this->decoratedStream->eof();
     }
@@ -96,7 +98,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function isSeekable()
+    public function isSeekable() : bool
     {
         return $this->decoratedStream->isSeekable();
     }
@@ -104,26 +106,27 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET) : void
     {
         if ($whence == SEEK_SET) {
-            return $this->decoratedStream->seek($offset + $this->offset, $whence);
+            $this->decoratedStream->seek($offset + $this->offset, $whence);
+            return;
         }
-        return $this->decoratedStream->seek($offset, $whence);
+        $this->decoratedStream->seek($offset, $whence);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind() : void
     {
-        return $this->seek(0);
+        $this->seek(0);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isWritable()
+    public function isWritable() : bool
     {
         return $this->decoratedStream->isWritable();
     }
@@ -131,7 +134,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function write($string)
+    public function write($string) : int
     {
         if ($this->tell() < 0) {
             throw new Exception\InvalidStreamPointerPositionException();
@@ -142,7 +145,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function isReadable()
+    public function isReadable() : bool
     {
         return $this->decoratedStream->isReadable();
     }
@@ -150,7 +153,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function read($length)
+    public function read($length) : string
     {
         if ($this->tell() < 0) {
             throw new Exception\InvalidStreamPointerPositionException();
@@ -161,7 +164,7 @@ final class RelativeStream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getContents()
+    public function getContents() : string
     {
         if ($this->tell() < 0) {
             throw new Exception\InvalidStreamPointerPositionException();

--- a/src/Request.php
+++ b/src/Request.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\RequestInterface;
@@ -29,9 +31,9 @@ class Request implements RequestInterface
      * @param null|string $method HTTP method for the request, if any.
      * @param string|resource|StreamInterface $body Message body, if any.
      * @param array $headers Headers for the message, if any.
-     * @throws \InvalidArgumentException for any invalid value.
+     * @throws Exception\InvalidArgumentException for any invalid value.
      */
-    public function __construct($uri = null, $method = null, $body = 'php://temp', array $headers = [])
+    public function __construct($uri = null, string $method = null, $body = 'php://temp', array $headers = [])
     {
         $this->initialize($uri, $method, $body, $headers);
     }
@@ -39,7 +41,7 @@ class Request implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeaders()
+    public function getHeaders() : array
     {
         $headers = $this->headers;
         if (! $this->hasHeader('host')
@@ -54,7 +56,7 @@ class Request implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getHeader($header)
+    public function getHeader($header) : array
     {
         if (! $this->hasHeader($header)) {
             if (strtolower($header) === 'host'

--- a/src/Request/ArraySerializer.php
+++ b/src/Request/ArraySerializer.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Request;
 
 use Psr\Http\Message\RequestInterface;
@@ -26,11 +28,8 @@ final class ArraySerializer
 {
     /**
      * Serialize a request message to an array.
-     *
-     * @param RequestInterface $request
-     * @return array
      */
-    public static function toArray(RequestInterface $request)
+    public static function toArray(RequestInterface $request) : array
     {
         return [
             'method'           => $request->getMethod(),
@@ -45,11 +44,9 @@ final class ArraySerializer
     /**
      * Deserialize a request array to a request instance.
      *
-     * @param array $serializedRequest
-     * @return Request
      * @throws Exception\DeserializationException when cannot deserialize response
      */
-    public static function fromArray(array $serializedRequest)
+    public static function fromArray(array $serializedRequest) : Request
     {
         try {
             $uri             = self::getValueFromKey($serializedRequest, 'uri');
@@ -69,13 +66,10 @@ final class ArraySerializer
     }
 
     /**
-     * @param array $data
-     * @param string $key
-     * @param string $message
      * @return mixed
      * @throws Exception\DeserializationException
      */
-    private static function getValueFromKey(array $data, $key, $message = null)
+    private static function getValueFromKey(array $data, string $key, string $message = null)
     {
         if (isset($data[$key])) {
             return $data[$key];

--- a/src/Request/Serializer.php
+++ b/src/Request/Serializer.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Request;
 
 use Psr\Http\Message\RequestInterface;
@@ -32,11 +34,9 @@ final class Serializer extends AbstractSerializer
      *
      * Internally, casts the message to a stream and invokes fromStream().
      *
-     * @param string $message
-     * @return Request
-     * @throws UnexpectedValueException when errors occur parsing the message.
+     * @throws Exception\SerializationException when errors occur parsing the message.
      */
-    public static function fromString($message)
+    public static function fromString(string $message) : Request
     {
         $stream = new Stream('php://temp', 'wb+');
         $stream->write($message);
@@ -46,13 +46,11 @@ final class Serializer extends AbstractSerializer
     /**
      * Deserialize a request stream to a request instance.
      *
-     * @param StreamInterface $stream
-     * @return Request
      * @throws Exception\InvalidArgumentException if the message stream is not
      *     readable or seekable.
      * @throws Exception\SerializationException if an invalid request line is detected.
      */
-    public static function fromStream(StreamInterface $stream)
+    public static function fromStream(StreamInterface $stream) : Request
     {
         if (! $stream->isReadable() || ! $stream->isSeekable()) {
             throw new Exception\InvalidArgumentException('Message stream must be both readable and seekable');
@@ -60,10 +58,10 @@ final class Serializer extends AbstractSerializer
 
         $stream->rewind();
 
-        list($method, $requestTarget, $version) = self::getRequestLine($stream);
+        [$method, $requestTarget, $version] = self::getRequestLine($stream);
         $uri = self::createUriFromRequestTarget($requestTarget);
 
-        list($headers, $body) = self::splitStream($stream);
+        [$headers, $body] = self::splitStream($stream);
 
         return (new Request($uri, $method, $body, $headers))
             ->withProtocolVersion($version)
@@ -72,11 +70,8 @@ final class Serializer extends AbstractSerializer
 
     /**
      * Serialize a request message to a string.
-     *
-     * @param RequestInterface $request
-     * @return string
      */
-    public static function toString(RequestInterface $request)
+    public static function toString(RequestInterface $request) : string
     {
         $httpMethod = $request->getMethod();
         $headers = self::serializeHeaders($request->getHeaders());
@@ -107,11 +102,9 @@ final class Serializer extends AbstractSerializer
      * exception if it does not follow specifications; if valid, returns a list
      * with the method, target, and version, in that order.
      *
-     * @param StreamInterface $stream
-     * @return array
      * @throws Exception\SerializationException
      */
-    private static function getRequestLine(StreamInterface $stream)
+    private static function getRequestLine(StreamInterface $stream) : array
     {
         $requestLine = self::getLine($stream);
 
@@ -132,11 +125,8 @@ final class Serializer extends AbstractSerializer
      * If the request target is of authority or asterisk form, an empty Uri
      * instance is returned; otherwise, the value is used to create and return
      * a new Uri instance.
-     *
-     * @param string $requestTarget
-     * @return Uri
      */
-    private static function createUriFromRequestTarget($requestTarget)
+    private static function createUriFromRequestTarget(string $requestTarget) : Uri
     {
         if (preg_match('#^https?://#', $requestTarget)) {
             return new Uri($requestTarget);

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\RequestFactoryInterface;

--- a/src/RequestTrait.php
+++ b/src/RequestTrait.php
@@ -5,8 +5,11 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -61,8 +64,12 @@ trait RequestTrait
      * @param array $headers Headers for the message, if any.
      * @throws Exception\InvalidArgumentException for any invalid value.
      */
-    private function initialize($uri = null, $method = null, $body = 'php://memory', array $headers = [])
-    {
+    private function initialize(
+        $uri = null,
+        string $method = null,
+        $body = 'php://memory',
+        array $headers = []
+    ) : void {
         if ($method !== null) {
             $this->setMethod($method);
         }
@@ -93,10 +100,9 @@ trait RequestTrait
      * Otherwise, it raises an exception.
      *
      * @param null|string|UriInterface $uri
-     * @return UriInterface
      * @throws Exception\InvalidArgumentException
      */
-    private function createUri($uri)
+    private function createUri($uri) : UriInterface
     {
         if ($uri instanceof UriInterface) {
             return $uri;
@@ -125,10 +131,8 @@ trait RequestTrait
      *
      * If no URI is available, and no request-target has been specifically
      * provided, this method MUST return the string "/".
-     *
-     * @return string
      */
-    public function getRequestTarget()
+    public function getRequestTarget() : string
     {
         if (null !== $this->requestTarget) {
             return $this->requestTarget;
@@ -160,11 +164,10 @@ trait RequestTrait
      *
      * @link http://tools.ietf.org/html/rfc7230#section-2.7 (for the various
      *     request-target forms allowed in request messages)
-     * @param mixed $requestTarget
-     * @return static
+     * @param string $requestTarget
      * @throws Exception\InvalidArgumentException if the request target is invalid.
      */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget($requestTarget) : RequestInterface
     {
         if (preg_match('#\s#', $requestTarget)) {
             throw new Exception\InvalidArgumentException(
@@ -182,7 +185,7 @@ trait RequestTrait
      *
      * @return string Returns the request method.
      */
-    public function getMethod()
+    public function getMethod() : string
     {
         return $this->method;
     }
@@ -199,10 +202,9 @@ trait RequestTrait
      * changed request method.
      *
      * @param string $method Case-insensitive method.
-     * @return static
      * @throws Exception\InvalidArgumentException for invalid HTTP methods.
      */
-    public function withMethod($method)
+    public function withMethod($method) : RequestInterface
     {
         $new = clone $this;
         $new->setMethod($method);
@@ -218,7 +220,7 @@ trait RequestTrait
      * @return UriInterface Returns a UriInterface instance
      *     representing the URI of the request, if any.
      */
-    public function getUri()
+    public function getUri() : UriInterface
     {
         return $this->uri;
     }
@@ -246,9 +248,8 @@ trait RequestTrait
      * @link http://tools.ietf.org/html/rfc3986#section-4.3
      * @param UriInterface $uri New request URI to use.
      * @param bool $preserveHost Preserve the original state of the Host header.
-     * @return static
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, $preserveHost = false) : RequestInterface
     {
         $new = clone $this;
         $new->uri = $uri;
@@ -288,7 +289,7 @@ trait RequestTrait
      * @param string $method
      * @throws Exception\InvalidArgumentException on invalid HTTP method.
      */
-    private function setMethod($method)
+    private function setMethod($method) : void
     {
         if (! is_string($method)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -308,10 +309,8 @@ trait RequestTrait
 
     /**
      * Retrieve the host from the URI instance
-     *
-     * @return string
      */
-    private function getHostFromUri()
+    private function getHostFromUri() : string
     {
         $host  = $this->uri->getHost();
         $host .= $this->uri->getPort() ? ':' . $this->uri->getPort() : '';

--- a/src/Response.php
+++ b/src/Response.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\ResponseInterface;
@@ -125,7 +127,7 @@ class Response implements ResponseInterface
      * @param array $headers Headers for the response, if any.
      * @throws Exception\InvalidArgumentException on any invalid element.
      */
-    public function __construct($body = 'php://memory', $status = 200, array $headers = [])
+    public function __construct($body = 'php://memory', int $status = 200, array $headers = [])
     {
         $this->setStatusCode($status);
         $this->stream = $this->getStream($body, 'wb+');
@@ -135,7 +137,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getStatusCode()
+    public function getStatusCode() : int
     {
         return $this->statusCode;
     }
@@ -143,7 +145,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase() : string
     {
         return $this->reasonPhrase;
     }
@@ -151,7 +153,7 @@ class Response implements ResponseInterface
     /**
      * {@inheritdoc}
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = '') : Response
     {
         $new = clone $this;
         $new->setStatusCode($code, $reasonPhrase);
@@ -165,7 +167,7 @@ class Response implements ResponseInterface
      * @param string $reasonPhrase
      * @throws Exception\InvalidArgumentException on an invalid status code.
      */
-    private function setStatusCode($code, $reasonPhrase = '')
+    private function setStatusCode($code, $reasonPhrase = '') : void
     {
         if (! is_numeric($code)
             || is_float($code)

--- a/src/Response/ArraySerializer.php
+++ b/src/Response/ArraySerializer.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Response;
 
 use Psr\Http\Message\ResponseInterface;
@@ -26,11 +28,8 @@ final class ArraySerializer
 {
     /**
      * Serialize a response message to an array.
-     *
-     * @param ResponseInterface $response
-     * @return array
      */
-    public static function toArray(ResponseInterface $response)
+    public static function toArray(ResponseInterface $response) : array
     {
         return [
             'status_code'      => $response->getStatusCode(),
@@ -44,11 +43,9 @@ final class ArraySerializer
     /**
      * Deserialize a response array to a response instance.
      *
-     * @param array $serializedResponse
-     * @return Response
      * @throws Exception\DeserializationException when cannot deserialize response
      */
-    public static function fromArray(array $serializedResponse)
+    public static function fromArray(array $serializedResponse) : Response
     {
         try {
             $body = new Stream('php://memory', 'wb+');
@@ -74,7 +71,7 @@ final class ArraySerializer
      * @return mixed
      * @throws UnexpectedValueException
      */
-    private static function getValueFromKey(array $data, $key, $message = null)
+    private static function getValueFromKey(array $data, string $key, string $message = null)
     {
         if (isset($data[$key])) {
             return $data[$key];

--- a/src/Response/EmptyResponse.php
+++ b/src/Response/EmptyResponse.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Diactoros\Response;
 
@@ -23,7 +23,7 @@ class EmptyResponse extends Response
      * @param int $status Status code for the response, if any.
      * @param array $headers Headers for the response, if any.
      */
-    public function __construct($status = 204, array $headers = [])
+    public function __construct(int $status = 204, array $headers = [])
     {
         $body = new Stream('php://temp', 'r');
         parent::__construct($body, $status, $headers);
@@ -35,7 +35,7 @@ class EmptyResponse extends Response
      * @param array $headers Headers for the response.
      * @return EmptyResponse
      */
-    public static function withHeaders(array $headers)
+    public static function withHeaders(array $headers) : EmptyResponse
     {
         return new static(204, $headers);
     }

--- a/src/Response/HtmlResponse.php
+++ b/src/Response/HtmlResponse.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Response;
 
 use Psr\Http\Message\StreamInterface;
@@ -40,7 +42,7 @@ class HtmlResponse extends Response
      * @param array $headers Array of headers to use at initialization.
      * @throws Exception\InvalidArgumentException if $html is neither a string or stream.
      */
-    public function __construct($html, $status = 200, array $headers = [])
+    public function __construct($html, int $status = 200, array $headers = [])
     {
         parent::__construct(
             $this->createBody($html),
@@ -53,10 +55,9 @@ class HtmlResponse extends Response
      * Create the message body.
      *
      * @param string|StreamInterface $html
-     * @return StreamInterface
      * @throws Exception\InvalidArgumentException if $html is neither a string or stream.
      */
-    private function createBody($html)
+    private function createBody($html) : StreamInterface
     {
         if ($html instanceof StreamInterface) {
             return $html;

--- a/src/Response/InjectContentTypeTrait.php
+++ b/src/Response/InjectContentTypeTrait.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Diactoros\Response;
 
@@ -18,11 +18,9 @@ trait InjectContentTypeTrait
     /**
      * Inject the provided Content-Type, if none is already present.
      *
-     * @param string $contentType
-     * @param array $headers
      * @return array Headers with injected Content-Type
      */
-    private function injectContentType($contentType, array $headers)
+    private function injectContentType(string $contentType, array $headers) : array
     {
         $hasContentType = array_reduce(array_keys($headers), function ($carry, $item) {
             return $carry ?: (strtolower($item) === 'content-type');

--- a/src/Response/JsonResponse.php
+++ b/src/Response/JsonResponse.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Response;
 
 use Zend\Diactoros\Exception;
@@ -72,9 +74,9 @@ class JsonResponse extends Response
      */
     public function __construct(
         $data,
-        $status = 200,
+        int $status = 200,
         array $headers = [],
-        $encodingOptions = self::DEFAULT_JSON_FLAGS
+        int $encodingOptions = self::DEFAULT_JSON_FLAGS
     ) {
         $this->setPayload($data);
         $this->encodingOptions = $encodingOptions;
@@ -96,43 +98,28 @@ class JsonResponse extends Response
     }
 
     /**
-     * @param $data
-     *
-     * @return JsonResponse
+     * @param mixed $data
      */
-    public function withPayload($data)
+    public function withPayload($data) : JsonResponse
     {
         $new = clone $this;
         $new->setPayload($data);
         return $this->updateBodyFor($new);
     }
 
-    /**
-     * @return int
-     */
-    public function getEncodingOptions()
+    public function getEncodingOptions() : int
     {
         return $this->encodingOptions;
     }
 
-    /**
-     * @param int $encodingOptions
-     *
-     * @return JsonResponse
-     */
-    public function withEncodingOptions($encodingOptions)
+    public function withEncodingOptions(int $encodingOptions) : JsonResponse
     {
         $new = clone $this;
         $new->encodingOptions = $encodingOptions;
         return $this->updateBodyFor($new);
     }
 
-    /**
-     * @param string $json
-     *
-     * @return Stream
-     */
-    private function createBodyFromJson($json)
+    private function createBodyFromJson(string $json) : Stream
     {
         $body = new Stream('php://temp', 'wb+');
         $body->write($json);
@@ -145,11 +132,9 @@ class JsonResponse extends Response
      * Encode the provided data to JSON.
      *
      * @param mixed $data
-     * @param int $encodingOptions
-     * @return string
      * @throws Exception\InvalidArgumentException if unable to encode the $data to JSON.
      */
-    private function jsonEncode($data, $encodingOptions)
+    private function jsonEncode($data, int $encodingOptions) : string
     {
         if (is_resource($data)) {
             throw new Exception\InvalidArgumentException('Cannot JSON encode resources');
@@ -172,9 +157,9 @@ class JsonResponse extends Response
     }
 
     /**
-     * @param $data
+     * @param mixed $data
      */
-    private function setPayload($data)
+    private function setPayload($data) : void
     {
         if (is_object($data)) {
             $data = clone $data;
@@ -189,7 +174,7 @@ class JsonResponse extends Response
      * @param self $toUpdate Instance to update.
      * @return JsonResponse Returns a new instance with an updated body.
      */
-    private function updateBodyFor(self $toUpdate)
+    private function updateBodyFor(JsonResponse $toUpdate) : JsonResponse
     {
         $json = $this->jsonEncode($toUpdate->payload, $toUpdate->encodingOptions);
         $body = $this->createBodyFromJson($json);

--- a/src/Response/RedirectResponse.php
+++ b/src/Response/RedirectResponse.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Response;
 
 use Psr\Http\Message\UriInterface;
@@ -34,7 +36,7 @@ class RedirectResponse extends Response
      * @param int $status Integer status code for the redirect; 302 by default.
      * @param array $headers Array of headers to use at initialization.
      */
-    public function __construct($uri, $status = 302, array $headers = [])
+    public function __construct($uri, int $status = 302, array $headers = [])
     {
         if (! is_string($uri) && ! $uri instanceof UriInterface) {
             throw new Exception\InvalidArgumentException(sprintf(

--- a/src/Response/TextResponse.php
+++ b/src/Response/TextResponse.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Response;
 
 use Psr\Http\Message\StreamInterface;
@@ -40,7 +42,7 @@ class TextResponse extends Response
      * @param array $headers Array of headers to use at initialization.
      * @throws Exception\InvalidArgumentException if $text is neither a string or stream.
      */
-    public function __construct($text, $status = 200, array $headers = [])
+    public function __construct($text, int $status = 200, array $headers = [])
     {
         parent::__construct(
             $this->createBody($text),
@@ -53,10 +55,9 @@ class TextResponse extends Response
      * Create the message body.
      *
      * @param string|StreamInterface $text
-     * @return StreamInterface
      * @throws Exception\InvalidArgumentException if $html is neither a string or stream.
      */
-    private function createBody($text)
+    private function createBody($text) : StreamInterface
     {
         if ($text instanceof StreamInterface) {
             return $text;

--- a/src/Response/XmlResponse.php
+++ b/src/Response/XmlResponse.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros\Response;
 
 use Psr\Http\Message\StreamInterface;
@@ -41,7 +43,7 @@ class XmlResponse extends Response
      */
     public function __construct(
         $xml,
-        $status = 200,
+        int $status = 200,
         array $headers = []
     ) {
         parent::__construct(
@@ -55,10 +57,9 @@ class XmlResponse extends Response
      * Create the message body.
      *
      * @param string|StreamInterface $xml
-     * @return StreamInterface
      * @throws Exception\InvalidArgumentException if $xml is neither a string or stream.
      */
-    private function createBody($xml)
+    private function createBody($xml) : StreamInterface
     {
         if ($xml instanceof StreamInterface) {
             return $xml;

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\ResponseFactoryInterface;

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\ServerRequestInterface;
@@ -80,13 +82,13 @@ class ServerRequest implements ServerRequestInterface
         array $serverParams = [],
         array $uploadedFiles = [],
         $uri = null,
-        $method = null,
+        string $method = null,
         $body = 'php://input',
         array $headers = [],
         array $cookies = [],
         array $queryParams = [],
         $parsedBody = null,
-        $protocol = '1.1'
+        string $protocol = '1.1'
     ) {
         $this->validateUploadedFiles($uploadedFiles);
 
@@ -106,7 +108,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getServerParams()
+    public function getServerParams() : array
     {
         return $this->serverParams;
     }
@@ -114,7 +116,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getUploadedFiles()
+    public function getUploadedFiles() : array
     {
         return $this->uploadedFiles;
     }
@@ -122,7 +124,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles) : ServerRequest
     {
         $this->validateUploadedFiles($uploadedFiles);
         $new = clone $this;
@@ -133,7 +135,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getCookieParams()
+    public function getCookieParams() : array
     {
         return $this->cookieParams;
     }
@@ -141,7 +143,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies) : ServerRequest
     {
         $new = clone $this;
         $new->cookieParams = $cookies;
@@ -151,7 +153,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getQueryParams()
+    public function getQueryParams() : array
     {
         return $this->queryParams;
     }
@@ -159,7 +161,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query) : ServerRequest
     {
         $new = clone $this;
         $new->queryParams = $query;
@@ -177,7 +179,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withParsedBody($data)
+    public function withParsedBody($data) : ServerRequest
     {
         if (! is_array($data) && ! is_object($data) && null !== $data) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -195,7 +197,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes() : array
     {
         return $this->attributes;
     }
@@ -215,7 +217,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withAttribute($attribute, $value)
+    public function withAttribute($attribute, $value) : ServerRequest
     {
         $new = clone $this;
         $new->attributes[$attribute] = $value;
@@ -225,7 +227,7 @@ class ServerRequest implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutAttribute($attribute)
+    public function withoutAttribute($attribute) : ServerRequest
     {
         $new = clone $this;
         unset($new->attributes[$attribute]);
@@ -235,10 +237,9 @@ class ServerRequest implements ServerRequestInterface
     /**
      * Recursively validate the structure in an uploaded files array.
      *
-     * @param array $uploadedFiles
      * @throws Exception\InvalidArgumentException if any leaf is not an UploadedFileInterface instance.
      */
-    private function validateUploadedFiles(array $uploadedFiles)
+    private function validateUploadedFiles(array $uploadedFiles) : void
     {
         foreach ($uploadedFiles as $file) {
             if (is_array($file)) {

--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -53,7 +55,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         array $body = null,
         array $cookies = null,
         array $files = null
-    ) {
+    ) : ServerRequest {
         $server = normalizeServer(
             $server ?: $_SERVER,
             is_callable(self::$apacheRequestHeaders) ? self::$apacheRequestHeaders : null

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
@@ -52,7 +54,7 @@ class Stream implements StreamInterface
      * @param string $mode Mode with which to open stream
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($stream, $mode = 'r')
+    public function __construct($stream, string $mode = 'r')
     {
         $this->setStream($stream, $mode);
     }
@@ -60,7 +62,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString() : string
     {
         if (! $this->isReadable()) {
             return '';
@@ -80,7 +82,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function close()
+    public function close() : void
     {
         if (! $this->resource) {
             return;
@@ -109,7 +111,7 @@ class Stream implements StreamInterface
      *     cast to a resource
      * @throws Exception\InvalidArgumentException for non-resource stream
      */
-    public function attach($resource, $mode = 'r')
+    public function attach($resource, string $mode = 'r') : void
     {
         $this->setStream($resource, $mode);
     }
@@ -117,7 +119,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getSize()
+    public function getSize() : ?int
     {
         if (null === $this->resource) {
             return null;
@@ -134,7 +136,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function tell()
+    public function tell() : int
     {
         if (! $this->resource) {
             throw Exception\UntellableStreamException::dueToMissingResource();
@@ -151,7 +153,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function eof()
+    public function eof() : bool
     {
         if (! $this->resource) {
             return true;
@@ -163,7 +165,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function isSeekable()
+    public function isSeekable() : bool
     {
         if (! $this->resource) {
             return false;
@@ -176,7 +178,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET) : void
     {
         if (! $this->resource) {
             throw Exception\UnseekableStreamException::dueToMissingResource();
@@ -191,22 +193,20 @@ class Stream implements StreamInterface
         if (0 !== $result) {
             throw Exception\UnseekableStreamException::dueToPhpError();
         }
-
-        return true;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind() : void
     {
-        return $this->seek(0);
+        $this->seek(0);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isWritable()
+    public function isWritable() : bool
     {
         if (! $this->resource) {
             return false;
@@ -227,7 +227,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function write($string)
+    public function write($string) : int
     {
         if (! $this->resource) {
             throw Exception\UnwritableStreamException::dueToMissingResource();
@@ -242,13 +242,14 @@ class Stream implements StreamInterface
         if (false === $result) {
             throw Exception\UnwritableStreamException::dueToPhpError();
         }
+
         return $result;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isReadable()
+    public function isReadable() : bool
     {
         if (! $this->resource) {
             return false;
@@ -263,7 +264,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function read($length)
+    public function read($length) : string
     {
         if (! $this->resource) {
             throw Exception\UnreadableStreamException::dueToMissingResource();
@@ -285,7 +286,7 @@ class Stream implements StreamInterface
     /**
      * {@inheritdoc}
      */
-    public function getContents()
+    public function getContents() : string
     {
         if (! $this->isReadable()) {
             throw Exception\UnreadableStreamException::dueToConfiguration();
@@ -322,7 +323,7 @@ class Stream implements StreamInterface
      * @param string $mode Resource mode for stream target.
      * @throws Exception\InvalidArgumentException for invalid streams or resources.
      */
-    private function setStream($stream, $mode = 'r')
+    private function setStream($stream, string $mode = 'r') : void
     {
         $error    = null;
         $resource = $stream;

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamFactoryInterface;

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\StreamInterface;
@@ -90,8 +92,13 @@ class UploadedFile implements UploadedFileInterface
      * @param string|null $clientMediaType
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($streamOrFile, $size, $errorStatus, $clientFilename = null, $clientMediaType = null)
-    {
+    public function __construct(
+        $streamOrFile,
+        int $size,
+        int $errorStatus,
+        string $clientFilename = null,
+        string $clientMediaType = null
+    ) {
         if ($errorStatus === UPLOAD_ERR_OK) {
             if (is_string($streamOrFile)) {
                 $this->file = $streamOrFile;
@@ -108,33 +115,16 @@ class UploadedFile implements UploadedFileInterface
             }
         }
 
-        if (! is_int($size)) {
-            throw new Exception\InvalidArgumentException('Invalid size provided for UploadedFile; must be an int');
-        }
         $this->size = $size;
 
-        if (! is_int($errorStatus)
-            || 0 > $errorStatus
-            || 8 < $errorStatus
-        ) {
+        if (0 > $errorStatus || 8 < $errorStatus) {
             throw new Exception\InvalidArgumentException(
                 'Invalid error status for UploadedFile; must be an UPLOAD_ERR_* constant'
             );
         }
         $this->error = $errorStatus;
 
-        if (null !== $clientFilename && ! is_string($clientFilename)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid client filename provided for UploadedFile; must be null or a string'
-            );
-        }
         $this->clientFilename = $clientFilename;
-
-        if (null !== $clientMediaType && ! is_string($clientMediaType)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid client media type provided for UploadedFile; must be null or a string'
-            );
-        }
         $this->clientMediaType = $clientMediaType;
     }
 
@@ -143,7 +133,7 @@ class UploadedFile implements UploadedFileInterface
      * @throws Exception\UploadedFileAlreadyMovedException if the upload was
      *     not successful.
      */
-    public function getStream()
+    public function getStream() : StreamInterface
     {
         if ($this->error !== UPLOAD_ERR_OK) {
             throw Exception\UploadedFileErrorException::dueToStreamUploadError(
@@ -174,7 +164,7 @@ class UploadedFile implements UploadedFileInterface
      * @throws Exception\UploadedFileErrorException on any error during the
      *     move operation, or on the second or subsequent call to the method.
      */
-    public function moveTo($targetPath)
+    public function moveTo($targetPath) : void
     {
         if ($this->moved) {
             throw new Exception\UploadedFileAlreadyMovedException('Cannot move file; already moved!');
@@ -219,7 +209,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @return int|null The file size in bytes or null if unknown.
      */
-    public function getSize()
+    public function getSize() : ?int
     {
         return $this->size;
     }
@@ -230,7 +220,7 @@ class UploadedFile implements UploadedFileInterface
      * @see http://php.net/manual/en/features.file-upload.errors.php
      * @return int One of PHP's UPLOAD_ERR_XXX constants.
      */
-    public function getError()
+    public function getError() : int
     {
         return $this->error;
     }
@@ -241,7 +231,7 @@ class UploadedFile implements UploadedFileInterface
      * @return string|null The filename sent by the client or null if none
      *     was provided.
      */
-    public function getClientFilename()
+    public function getClientFilename() : ?string
     {
         return $this->clientFilename;
     }
@@ -249,7 +239,7 @@ class UploadedFile implements UploadedFileInterface
     /**
      * {@inheritdoc}
      */
-    public function getClientMediaType()
+    public function getClientMediaType() : ?string
     {
         return $this->clientMediaType;
     }
@@ -259,7 +249,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @param string $path
      */
-    private function writeFile($path)
+    private function writeFile(string $path) : void
     {
         $handle = fopen($path, 'wb+');
         if (false === $handle) {

--- a/src/UploadedFileFactory.php
+++ b/src/UploadedFileFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\UploadedFileFactoryInterface;

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\UriInterface;
@@ -104,21 +106,10 @@ class Uri implements UriInterface
      */
     private $uriString;
 
-    /**
-     * @param string $uri
-     * @throws Exception\InvalidArgumentException on non-string $uri argument
-     */
-    public function __construct($uri = '')
+    public function __construct(string $uri = '')
     {
         if ('' === $uri) {
             return;
-        }
-
-        if (! is_string($uri)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'URI passed to constructor must be a string; received "%s"',
-                is_object($uri) ? get_class($uri) : gettype($uri)
-            ));
         }
 
         $this->parseUri($uri);
@@ -138,7 +129,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString() : string
     {
         if (null !== $this->uriString) {
             return $this->uriString;
@@ -158,7 +149,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getScheme()
+    public function getScheme() : string
     {
         return $this->scheme;
     }
@@ -166,7 +157,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getAuthority()
+    public function getAuthority() : string
     {
         if ('' === $this->host) {
             return '';
@@ -191,7 +182,7 @@ class Uri implements UriInterface
      *
      * {@inheritdoc}
      */
-    public function getUserInfo()
+    public function getUserInfo() : string
     {
         return $this->userInfo;
     }
@@ -199,7 +190,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getHost()
+    public function getHost() : string
     {
         return $this->host;
     }
@@ -207,7 +198,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getPort()
+    public function getPort() : ?int
     {
         return $this->isNonStandardPort($this->scheme, $this->host, $this->port)
             ? $this->port
@@ -217,7 +208,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getPath()
+    public function getPath() : string
     {
         return $this->path;
     }
@@ -225,7 +216,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getQuery()
+    public function getQuery() : string
     {
         return $this->query;
     }
@@ -233,7 +224,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function getFragment()
+    public function getFragment() : string
     {
         return $this->fragment;
     }
@@ -241,7 +232,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function withScheme($scheme)
+    public function withScheme($scheme) : UriInterface
     {
         if (! is_string($scheme)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -272,7 +263,7 @@ class Uri implements UriInterface
      *
      * {@inheritdoc}
      */
-    public function withUserInfo($user, $password = null)
+    public function withUserInfo($user, $password = null) : UriInterface
     {
         if (! is_string($user)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -308,7 +299,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function withHost($host)
+    public function withHost($host) : UriInterface
     {
         if (! is_string($host)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -332,7 +323,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function withPort($port)
+    public function withPort($port) : UriInterface
     {
         if ($port !== null) {
             if (! is_numeric($port) || is_float($port)) {
@@ -366,7 +357,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function withPath($path)
+    public function withPath($path) : UriInterface
     {
         if (! is_string($path)) {
             throw new Exception\InvalidArgumentException(
@@ -402,7 +393,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function withQuery($query)
+    public function withQuery($query) : UriInterface
     {
         if (! is_string($query)) {
             throw new Exception\InvalidArgumentException(
@@ -432,7 +423,7 @@ class Uri implements UriInterface
     /**
      * {@inheritdoc}
      */
-    public function withFragment($fragment)
+    public function withFragment($fragment) : UriInterface
     {
         if (! is_string($fragment)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -457,10 +448,8 @@ class Uri implements UriInterface
 
     /**
      * Parse a URI into its parts, and set the properties
-     *
-     * @param string $uri
      */
-    private function parseUri($uri)
+    private function parseUri(string $uri) : void
     {
         $parts = parse_url($uri);
 
@@ -485,16 +474,14 @@ class Uri implements UriInterface
 
     /**
      * Create a URI string from its various parts
-     *
-     * @param string $scheme
-     * @param string $authority
-     * @param string $path
-     * @param string $query
-     * @param string $fragment
-     * @return string
      */
-    private static function createUriString($scheme, $authority, $path, $query, $fragment)
-    {
+    private static function createUriString(
+        string $scheme,
+        string $authority,
+        string $path,
+        string $query,
+        string $fragment
+    ) : string {
         $uri = '';
 
         if ('' !== $scheme) {
@@ -525,13 +512,8 @@ class Uri implements UriInterface
 
     /**
      * Is a given port non-standard for the current scheme?
-     *
-     * @param string $scheme
-     * @param string $host
-     * @param int $port
-     * @return bool
      */
-    private function isNonStandardPort($scheme, $host, $port)
+    private function isNonStandardPort(string $scheme, string $host, ?int $port) : bool
     {
         if ('' === $scheme) {
             return '' === $host || null !== $port;
@@ -548,10 +530,9 @@ class Uri implements UriInterface
      * Filters the scheme to ensure it is a valid scheme.
      *
      * @param string $scheme Scheme name.
-     *
      * @return string Filtered scheme.
      */
-    private function filterScheme($scheme)
+    private function filterScheme(string $scheme) : string
     {
         $scheme = strtolower($scheme);
         $scheme = preg_replace('#:(//)?$#', '', $scheme);
@@ -577,7 +558,7 @@ class Uri implements UriInterface
      * @param string $part
      * @return string
      */
-    private function filterUserInfoPart($part)
+    private function filterUserInfoPart(string $part) : string
     {
         // Note the addition of `%` to initial charset; this allows `|` portion
         // to match and thus prevent double-encoding.
@@ -590,11 +571,8 @@ class Uri implements UriInterface
 
     /**
      * Filters the path of a URI to ensure it is properly encoded.
-     *
-     * @param string $path
-     * @return string
      */
-    private function filterPath($path)
+    private function filterPath(string $path) : string
     {
         $path = preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . ')(:@&=\+\$,\/;%]+|%(?![A-Fa-f0-9]{2}))/u',
@@ -620,11 +598,8 @@ class Uri implements UriInterface
      * Filter a query string to ensure it is propertly encoded.
      *
      * Ensures that the values in the query string are properly urlencoded.
-     *
-     * @param string $query
-     * @return string
      */
-    private function filterQuery($query)
+    private function filterQuery(string $query) : string
     {
         if ('' !== $query && strpos($query, '?') === 0) {
             $query = substr($query, 1);
@@ -632,7 +607,7 @@ class Uri implements UriInterface
 
         $parts = explode('&', $query);
         foreach ($parts as $index => $part) {
-            list($key, $value) = $this->splitQueryValue($part);
+            [$key, $value] = $this->splitQueryValue($part);
             if ($value === null) {
                 $parts[$index] = $this->filterQueryOrFragment($key);
                 continue;
@@ -653,7 +628,7 @@ class Uri implements UriInterface
      * @param string $value
      * @return array A value with exactly two elements, key and value
      */
-    private function splitQueryValue($value)
+    private function splitQueryValue(string $value) : array
     {
         $data = explode('=', $value, 2);
         if (! isset($data[1])) {
@@ -664,11 +639,8 @@ class Uri implements UriInterface
 
     /**
      * Filter a fragment value to ensure it is properly encoded.
-     *
-     * @param string $fragment
-     * @return string
      */
-    private function filterFragment($fragment)
+    private function filterFragment(string $fragment) : string
     {
         if ('' !== $fragment && strpos($fragment, '#') === 0) {
             $fragment = '%23' . substr($fragment, 1);
@@ -679,11 +651,8 @@ class Uri implements UriInterface
 
     /**
      * Filter a query string key or value, or a fragment.
-     *
-     * @param string $value
-     * @return string
      */
-    private function filterQueryOrFragment($value)
+    private function filterQueryOrFragment(string $value) : string
     {
         return preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]+|%(?![A-Fa-f0-9]{2}))/u',
@@ -694,11 +663,8 @@ class Uri implements UriInterface
 
     /**
      * URL encode a character returned by a regex.
-     *
-     * @param array $matches
-     * @return string
      */
-    private function urlEncodeChar(array $matches)
+    private function urlEncodeChar(array $matches) : string
     {
         return rawurlencode($matches[0]);
     }

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\UriFactoryInterface;

--- a/src/functions/create_uploaded_file.php
+++ b/src/functions/create_uploaded_file.php
@@ -5,17 +5,18 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 /**
  * Create an uploaded file instance from an array of values.
  *
  * @param array $spec A single $_FILES entry.
- * @return UploadedFile
  * @throws Exception\InvalidArgumentException if one or more of the tmp_name,
  *     size, or error keys are missing from $spec.
  */
-function createUploadedFile(array $spec)
+function createUploadedFile(array $spec) : UploadedFile
 {
     if (! isset($spec['tmp_name'])
         || ! isset($spec['size'])

--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function array_key_exists;
@@ -17,7 +19,7 @@ use function substr;
  * @param array $server Values obtained from the SAPI (generally `$_SERVER`).
  * @return array Header/value pairs
  */
-function marshalHeadersFromSapi(array $server)
+function marshalHeadersFromSapi(array $server) : array
 {
     $headers = [];
     foreach ($server as $key => $value) {

--- a/src/functions/marshal_method_from_sapi.php
+++ b/src/functions/marshal_method_from_sapi.php
@@ -5,15 +5,14 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 /**
  * Retrieve the request method from the SAPI parameters.
- *
- * @param array $server
- * @return string
  */
-function marshalMethodFromSapi(array $server)
+function marshalMethodFromSapi(array $server) : string
 {
     return isset($server['REQUEST_METHOD']) ? $server['REQUEST_METHOD'] : 'GET';
 }

--- a/src/functions/marshal_protocol_version_from_sapi.php
+++ b/src/functions/marshal_protocol_version_from_sapi.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function preg_match;
@@ -12,12 +14,10 @@ use function preg_match;
 /**
  * Return HTTP protocol version (X.Y) as discovered within a `$_SERVER` array.
  *
- * @param array $server
- * @return string
  * @throws Exception\UnrecognizedProtocolVersionException if the
  *     $server['SERVER_PROTOCOL'] value is malformed.
  */
-function marshalProtocolVersionFromSapi(array $server)
+function marshalProtocolVersionFromSapi(array $server) : string
 {
     if (! isset($server['SERVER_PROTOCOL'])) {
         return '1.1';

--- a/src/functions/marshal_uri_from_sapi.php
+++ b/src/functions/marshal_uri_from_sapi.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function array_change_key_case;
@@ -25,19 +27,17 @@ use function substr;
  *
  * @param array $server SAPI parameters
  * @param array $headers HTTP request headers
- * @return Uri
  */
-function marshalUriFromSapi(array $server, array $headers)
+function marshalUriFromSapi(array $server, array $headers) : Uri
 {
     /**
      * Retrieve a header value from an array of headers using a case-insensitive lookup.
      *
-     * @param string $name
      * @param array $headers Key/value header pairs
      * @param mixed $default Default value to return if header not found
      * @return mixed
      */
-    $getHeaderFromArray = function ($name, array $headers, $default = null) {
+    $getHeaderFromArray = function (string $name, array $headers, $default = null) {
         $header  = strtolower($name);
         $headers = array_change_key_case($headers, CASE_LOWER);
         if (array_key_exists($header, $headers)) {
@@ -51,12 +51,10 @@ function marshalUriFromSapi(array $server, array $headers)
     /**
      * Marshal the host and port from HTTP headers and/or the PHP environment.
      *
-     * @param array $headers
-     * @param array $server
      * @return array Array of two items, host and port, in that order (can be
      *     passed to a list() operation).
      */
-    $marshalHostAndPort = function (array $headers, array $server) use ($getHeaderFromArray) {
+    $marshalHostAndPort = function (array $headers, array $server) use ($getHeaderFromArray) : array {
         /**
         * @param string|array $host
         * @return array Array of two items, host and port, in that order (can be
@@ -79,13 +77,10 @@ function marshalUriFromSapi(array $server, array $headers)
         };
 
         /**
-        * @param array $server
-        * @param string $host
-        * @param null|int $port
         * @return array Array of two items, host and port, in that order (can be
         *     passed to a list() operation).
         */
-        $marshalIpv6HostAndPort = function (array $server, $host, $port) {
+        $marshalIpv6HostAndPort = function (array $server, string $host, ?int $port) : array {
             $host = '[' . $server['SERVER_ADDR'] . ']';
             $port = $port ?: 80;
             if ($port . ']' === substr($host, strrpos($host, ':') + 1)) {
@@ -133,11 +128,8 @@ function marshalUriFromSapi(array $server, array $headers)
      * From ZF2's Zend\Http\PhpEnvironment\Request class
      * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
      * @license   http://framework.zend.com/license/new-bsd New BSD License
-     *
-     * @param array $server SAPI environment array (typically `$_SERVER`)
-     * @return string Discovered path
      */
-    $marshalRequestPath = function (array $server) {
+    $marshalRequestPath = function (array $server) : string {
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
         $iisUrlRewritten = array_key_exists('IIS_WasUrlRewritten', $server) ? $server['IIS_WasUrlRewritten'] : null;
@@ -164,22 +156,37 @@ function marshalUriFromSapi(array $server, array $headers)
 
     // URI scheme
     $scheme = 'http';
+    $marshalHttpsValue = function ($https) : bool {
+        if (is_bool($https)) {
+            return $https;
+        }
+
+        if (! is_string($https)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'SAPI HTTPS value MUST be a string or boolean; received %s',
+                gettype($https)
+            ));
+        }
+
+        return 'off' !== strtolower($https);
+    };
     if (array_key_exists('HTTPS', $server)) {
-        $https = $server['HTTPS'];
+        $https = $marshalHttpsValue($server['HTTPS']);
     } elseif (array_key_exists('https', $server)) {
-        $https = $server['https'];
+        $https = $marshalHttpsValue($server['https']);
     } else {
         $https = false;
     }
-    if (($https && 'off' !== strtolower($https))
-        || strtolower($getHeaderFromArray('x-forwarded-proto', $headers, false)) === 'https'
+
+    if ($https
+        || strtolower($getHeaderFromArray('x-forwarded-proto', $headers, '')) === 'https'
     ) {
         $scheme = 'https';
     }
     $uri = $uri->withScheme($scheme);
 
     // Set the host
-    list($host, $port) = $marshalHostAndPort($headers, $server);
+    [$host, $port] = $marshalHostAndPort($headers, $server);
     if (! empty($host)) {
         $uri = $uri->withHost($host);
         if (! empty($port)) {
@@ -202,7 +209,7 @@ function marshalUriFromSapi(array $server, array $headers)
     // URI fragment
     $fragment = '';
     if (strpos($path, '#') !== false) {
-        list($path, $fragment) = explode('#', $path, 2);
+        [$path, $fragment] = explode('#', $path, 2);
     }
 
     return $uri

--- a/src/functions/normalize_server.php
+++ b/src/functions/normalize_server.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function is_callable;
@@ -16,13 +18,12 @@ use function is_callable;
  * attempts to detect the Authorization header, which is often not aggregated
  * correctly under various SAPI/httpd combinations.
  *
- * @param array $server
  * @param null|callable $apacheRequestHeaderCallback Callback that can be used to
  *     retrieve Apache request headers. This defaults to
  *     `apache_request_headers` under the Apache mod_php.
  * @return array Either $server verbatim, or with an added HTTP_AUTHORIZATION header.
  */
-function normalizeServer(array $server, callable $apacheRequestHeaderCallback = null)
+function normalizeServer(array $server, callable $apacheRequestHeaderCallback = null) : array
 {
     if (null === $apacheRequestHeaderCallback && is_callable('apache_request_headers')) {
         $apacheRequestHeaderCallback = 'apache_request_headers';

--- a/src/functions/normalize_uploaded_files.php
+++ b/src/functions/normalize_uploaded_files.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use Psr\Http\Message\UploadedFileInterface;
@@ -17,11 +19,10 @@ use function is_array;
  * Transforms each value into an UploadedFile instance, and ensures that nested
  * arrays are normalized.
  *
- * @param array $files
  * @return UploadedFileInterface[]
  * @throws Exception\InvalidArgumentException for unrecognized values
  */
-function normalizeUploadedFiles(array $files)
+function normalizeUploadedFiles(array $files) : array
 {
     /**
      * Traverse a nested tree of uploaded file specifications.
@@ -39,7 +40,7 @@ function normalizeUploadedFiles(array $files)
         array $errorTree,
         array $nameTree = null,
         array $typeTree = null
-    ) use (&$recursiveNormalize) {
+    ) use (&$recursiveNormalize) : array {
         $normalized = [];
         foreach ($tmpNameTree as $key => $value) {
             if (is_array($value)) {
@@ -78,7 +79,7 @@ function normalizeUploadedFiles(array $files)
      * @param array $files
      * @return UploadedFile[]
      */
-    $normalizeUploadedFileSpecification = function (array $files = []) use (&$recursiveNormalize) {
+    $normalizeUploadedFileSpecification = function (array $files = []) use (&$recursiveNormalize) : array {
         if (! isset($files['tmp_name']) || ! is_array($files['tmp_name'])
             || ! isset($files['size']) || ! is_array($files['size'])
             || ! isset($files['error']) || ! is_array($files['error'])

--- a/src/functions/parse_cookie_header.php
+++ b/src/functions/parse_cookie_header.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Diactoros;
 
 use function preg_match_all;
@@ -19,7 +21,7 @@ use function urldecode;
  * @param string $cookieHeader A string cookie header value.
  * @return array key/value cookie pairs.
  */
-function parseCookieHeader($cookieHeader)
+function parseCookieHeader($cookieHeader) : array
 {
     preg_match_all('(
         (?:^\\n?[ \t]*|;[ ])

--- a/test/CallbackStreamTest.php
+++ b/test/CallbackStreamTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 

--- a/test/HeaderSecurityTest.php
+++ b/test/HeaderSecurityTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 

--- a/test/Integration/RequestTest.php
+++ b/test/Integration/RequestTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\Integration;
 
 use Http\Psr7Test\RequestIntegrationTest;
@@ -13,14 +15,6 @@ use Zend\Diactoros\RequestFactory;
 
 class RequestTest extends RequestIntegrationTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (! class_exists(RequestFactory::class)) {
-            self::markTestSkipped('You need to install http-interop/http-factory-diactoros to run integration tests');
-        }
-        parent::setUpBeforeClass();
-    }
-
     public function createSubject()
     {
         return new Request('/', 'GET');

--- a/test/Integration/ResponseTest.php
+++ b/test/Integration/ResponseTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\Integration;
 
 use Http\Psr7Test\ResponseIntegrationTest;
@@ -13,14 +15,6 @@ use Zend\Diactoros\Response;
 
 class ResponseTest extends ResponseIntegrationTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (! class_exists(RequestFactory::class)) {
-            self::markTestSkipped('You need to install http-interop/http-factory-diactoros to run integration tests');
-        }
-        parent::setUpBeforeClass();
-    }
-
     public function createSubject()
     {
         return new Response();

--- a/test/Integration/ServerRequestTest.php
+++ b/test/Integration/ServerRequestTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\Integration;
 
 use Http\Psr7Test\ServerRequestIntegrationTest;
@@ -13,14 +15,6 @@ use Zend\Diactoros\ServerRequest;
 
 class ServerRequestTest extends ServerRequestIntegrationTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (! class_exists(RequestFactory::class)) {
-            self::markTestSkipped('You need to install http-interop/http-factory-diactoros to run integration tests');
-        }
-        parent::setUpBeforeClass();
-    }
-
     public function createSubject()
     {
         return new ServerRequest($_SERVER);

--- a/test/Integration/StreamTest.php
+++ b/test/Integration/StreamTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\Integration;
 
 use Http\Psr7Test\StreamIntegrationTest;
@@ -14,14 +16,6 @@ use Zend\Diactoros\Stream;
 
 class StreamTest extends StreamIntegrationTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (! class_exists(RequestFactory::class)) {
-            self::markTestSkipped('You need to install http-interop/http-factory-diactoros to run integration tests');
-        }
-        parent::setUpBeforeClass();
-    }
-
     public function createStream($data)
     {
         if ($data instanceof StreamInterface) {

--- a/test/Integration/UploadedFileTest.php
+++ b/test/Integration/UploadedFileTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\Integration;
 
 use Http\Psr7Test\UploadedFileIntegrationTest;
@@ -14,14 +16,6 @@ use Zend\Diactoros\UploadedFile;
 
 class UploadedFileTest extends UploadedFileIntegrationTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (! class_exists(RequestFactory::class)) {
-            self::markTestSkipped('You need to install http-interop/http-factory-diactoros to run integration tests');
-        }
-        parent::setUpBeforeClass();
-    }
-
     public function createSubject()
     {
         $stream = new Stream('php://memory', 'rw');

--- a/test/Integration/UriTest.php
+++ b/test/Integration/UriTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\Integration;
 
 use Http\Psr7Test\UriIntegrationTest;
@@ -13,14 +15,6 @@ use Zend\Diactoros\Uri;
 
 class UriTest extends UriIntegrationTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (! class_exists(RequestFactory::class)) {
-            self::markTestSkipped('You need to install http-interop/http-factory-diactoros to run integration tests');
-        }
-        parent::setUpBeforeClass();
-    }
-
     public function createUri($uri)
     {
         return new Uri($uri);

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 

--- a/test/PhpInputStreamTest.php
+++ b/test/PhpInputStreamTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 

--- a/test/RelativeStreamTest.php
+++ b/test/RelativeStreamTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 
@@ -98,19 +100,17 @@ class RelativeStreamTest extends TestCase
     public function testSeek()
     {
         $decorated = $this->prophesize(Stream::class);
-        $decorated->seek(126, SEEK_SET)->shouldBeCalled()->willReturn(0);
+        $decorated->seek(126, SEEK_SET)->shouldBeCalled();
         $stream = new RelativeStream($decorated->reveal(), 100);
-        $ret = $stream->seek(26);
-        $this->assertSame(0, $ret);
+        $this->assertNull($stream->seek(26));
     }
 
     public function testRewind()
     {
         $decorated = $this->prophesize(Stream::class);
-        $decorated->seek(100, SEEK_SET)->shouldBeCalled()->willReturn(0);
+        $decorated->seek(100, SEEK_SET)->shouldBeCalled();
         $stream = new RelativeStream($decorated->reveal(), 100);
-        $ret = $stream->rewind();
-        $this->assertSame(0, $ret);
+        $this->assertNull($stream->rewind());
     }
 
     public function testWrite()

--- a/test/Request/ArraySerializerTest.php
+++ b/test/Request/ArraySerializerTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Request;
 

--- a/test/Request/SerializerTest.php
+++ b/test/Request/SerializerTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Request;
 

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 
@@ -144,13 +146,7 @@ class RequestTest extends TestCase
     public function invalidRequestMethod()
     {
         return [
-            'true'       => [ true ],
-            'false'      => [ false ],
-            'int'        => [ 1 ],
-            'float'      => [ 1.1 ],
             'bad-string' => [ 'BOGUS METHOD' ],
-            'array'      => [ ['POST'] ],
-            'stdClass'   => [ (object) [ 'method' => 'POST'] ],
         ];
     }
 

--- a/test/Response/ArraySerializerTest.php
+++ b/test/Response/ArraySerializerTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/EmptyResponseTest.php
+++ b/test/Response/EmptyResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/HtmlResponseTest.php
+++ b/test/Response/HtmlResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/JsonResponseTest.php
+++ b/test/Response/JsonResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/RedirectResponseTest.php
+++ b/test/Response/RedirectResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/SerializerTest.php
+++ b/test/Response/SerializerTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/TextResponseTest.php
+++ b/test/Response/TextResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/Response/XmlResponseTest.php
+++ b/test/Response/XmlResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros\Response;
 

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 
@@ -182,17 +184,6 @@ class ResponseTest extends TestCase
     /**
      * @dataProvider invalidStatusCodes
      */
-    public function testConstructorRaisesExceptionForInvalidStatus($code)
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid status code');
-
-        new Response('php://memory', $code);
-    }
-
-    /**
-     * @dataProvider invalidStatusCodes
-     */
     public function testCannotSetInvalidStatusCode($code)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -260,13 +251,6 @@ class ResponseTest extends TestCase
         $this->expectExceptionMessage($contains);
 
         new Response('php://memory', 200, $headers);
-    }
-
-    public function testInvalidStatusCodeInConstructor()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Response('php://memory', null);
     }
 
     public function testReasonPhraseCanBeEmpty()

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 
@@ -241,7 +243,7 @@ class StreamTest extends TestCase
         file_put_contents($this->tmpnam, 'FOO BAR');
         $resource = fopen($this->tmpnam, 'wb+');
         $stream = new Stream($resource);
-        $this->assertTrue($stream->seek(2));
+        $this->assertNull($stream->seek(2));
         $this->assertSame(2, $stream->tell());
     }
 
@@ -251,7 +253,7 @@ class StreamTest extends TestCase
         file_put_contents($this->tmpnam, 'FOO BAR');
         $resource = fopen($this->tmpnam, 'wb+');
         $stream = new Stream($resource);
-        $this->assertTrue($stream->seek(2));
+        $this->assertNull($stream->seek(2));
         $stream->rewind();
         $this->assertSame(0, $stream->tell());
     }

--- a/test/TestAsset/HeaderStack.php
+++ b/test/TestAsset/HeaderStack.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros\TestAsset;
 
 /**

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 
@@ -44,7 +46,7 @@ class UploadedFileTest extends TestCase
 
     public function tearDown()
     {
-        if (is_scalar($this->tmpFile) && file_exists($this->tmpFile)) {
+        if (is_string($this->tmpFile) && file_exists($this->tmpFile)) {
             unlink($this->tmpFile);
         }
     }
@@ -76,30 +78,6 @@ class UploadedFileTest extends TestCase
         new UploadedFile($streamOrFile, 0, UPLOAD_ERR_OK);
     }
 
-    public function invalidSizes()
-    {
-        return [
-            'null'   => [null],
-            'true'   => [true],
-            'false'  => [false],
-            'float'  => [1.1],
-            'string' => ['1'],
-            'array'  => [[1]],
-            'object' => [(object) [1]],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidSizes
-     */
-    public function testRaisesExceptionOnInvalidSize($size)
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('size');
-
-        new UploadedFile(fopen('php://temp', 'wb+'), $size, UPLOAD_ERR_OK);
-    }
-
     public function testValidSize()
     {
         $uploaded = new UploadedFile(fopen('php://temp', 'wb+'), 123, UPLOAD_ERR_OK);
@@ -110,13 +88,6 @@ class UploadedFileTest extends TestCase
     public function invalidErrorStatuses()
     {
         return [
-            'null'     => [null],
-            'true'     => [true],
-            'false'    => [false],
-            'float'    => [1.1],
-            'string'   => ['1'],
-            'array'    => [[1]],
-            'object'   => [(object) [1]],
             'negative' => [-1],
             'too-big'  => [9],
         ];
@@ -133,29 +104,6 @@ class UploadedFileTest extends TestCase
         new UploadedFile(fopen('php://temp', 'wb+'), 0, $status);
     }
 
-    public function invalidFilenamesAndMediaTypes()
-    {
-        return [
-            'true'   => [true],
-            'false'  => [false],
-            'int'    => [1],
-            'float'  => [1.1],
-            'array'  => [['string']],
-            'object' => [(object) ['string']],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidFilenamesAndMediaTypes
-     */
-    public function testRaisesExceptionOnInvalidClientFilename($filename)
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('filename');
-
-        new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, $filename);
-    }
-
     public function testValidClientFilename()
     {
         $file = new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, 'boo.txt');
@@ -166,17 +114,6 @@ class UploadedFileTest extends TestCase
     {
         $file = new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, null);
         $this->assertSame(null, $file->getClientFilename());
-    }
-
-    /**
-     * @dataProvider invalidFilenamesAndMediaTypes
-     */
-    public function testRaisesExceptionOnInvalidClientMediaType($mediaType)
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('media type');
-
-        new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, 'foobar.baz', $mediaType);
     }
 
     public function testValidClientMediaType()

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);
 
 namespace ZendTest\Diactoros;
 
@@ -337,29 +339,6 @@ class UriTest extends TestCase
     {
         $uri = new Uri('?foo=bar');
         $this->assertSame('?foo=bar', (string) $uri);
-    }
-
-    public function invalidConstructorUris()
-    {
-        return [
-            'null' => [ null ],
-            'true' => [ true ],
-            'false' => [ false ],
-            'int' => [ 1 ],
-            'float' => [ 1.1 ],
-            'array' => [ [ 'http://example.com/' ] ],
-            'object' => [ (object) [ 'uri' => 'http://example.com/' ] ],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidConstructorUris
-     */
-    public function testConstructorRaisesExceptionForNonStringURI($uri)
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new Uri($uri);
     }
 
     public function testConstructorRaisesExceptionForSeriouslyMalformedURI()

--- a/test/functions/NormalizeUploadedFilesTest.php
+++ b/test/functions/NormalizeUploadedFilesTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Diactoros;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Adds RTH and scalar type hints wherever possible. However, in many cases, because we are implementing interfaces, we cannot provide parameter type hints without conflicting with the interface; return type hints are allowed, though, due to PHP's contravariant return type rules.

Constructors always add parameter types, however, which eliminates the need for many unit tests, as well as type checks within the constructors.

A number of additional code changes were made due to enabling strict types. In some cases, we were returning values that we should not have been based on the return signature. In other cases, we were not casting values before passing them to functions or methods, and should have.