### PR TITLE
Fixed serverRequest factory

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -92,7 +92,8 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             $serverParams,
             $uploadedFiles,
             $uri,
-            $method
+            $method,
+            'php://temp'
         );
     }
 }

--- a/test/Integration/ServerRequestFactoryTest.php
+++ b/test/Integration/ServerRequestFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Diactoros\Integration;
+
+use Http\Psr7Test\ServerRequestIntegrationTest;
+use Zend\Diactoros\ServerRequestFactory;
+
+class ServerRequestFactoryTest extends ServerRequestIntegrationTest
+{
+    public function createSubject()
+    {
+        return (new ServerRequestFactory())->createServerRequest('GET', '/', $_SERVER);
+    }
+}

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -570,4 +570,15 @@ class ServerRequestFactoryTest extends TestCase
         $uri = marshalUriFromSapi($server, $headers);
         $this->assertSame('/requested/path', $uri->getPath());
     }
+
+    public function testServerRequestFactoryHasAWritableEmptyBody()
+    {
+        $factory = new ServerRequestFactory();
+        $request = $factory->createServerRequest('GET', '/');
+        $body = $request->getBody();
+
+        $this->assertTrue($body->isWritable());
+        $this->assertTrue($body->isSeekable());
+        $this->assertSame(0, $body->getSize());
+    }
 }


### PR DESCRIPTION
This fixes the `ServerRequestFactory` that always creates a server request with `php://input` as the body stream.
