### PR TITLE
Updated export-ignores to cleanup release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
-/doc export-ignore
+/docs export-ignore
 /test export-ignore
 /vendor export-ignore
+.coveralls.yml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
+composer.lock export-ignore
+mkdocs.yml export-ignore
 phpunit.xml.dist export-ignore
 phpcs.xml export-ignore


### PR DESCRIPTION
Not sure how this fits the PR template, so I left it out.

I noticed some files in the downloaded package from packagist that should not be there.

![image](https://user-images.githubusercontent.com/11173689/49410158-e88a4980-f763-11e8-93e1-2f3591d32233.png)

Result should be
```
src/
CHANGELOG.md
LICENSE.md
README.md
composer.json
```

Proposed contents are based on other zend projects like
https://github.com/zendframework/zend-httphandlerrunner/blob/master/.gitattributes
https://github.com/zendframework/zend-expressive/blob/master/.gitattributes