### PR TITLE
Updates configuration for MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,6 @@ pages:
     - "_reference-serialization": serialization.md
     - "_reference-api": api.md
 site_name: zend-diactoros
-site_description: 'zend-diactoros: PSR-7 HTTP message implementation'
+site_description: 'PSR-7 HTTP message implementations.'
 repo_url: 'https://github.com/zendframework/zend-diactoros'
 copyright: 'Copyright (c) 2016-2018 <a href="https://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,4 +31,3 @@ pages:
 site_name: zend-diactoros
 site_description: 'PSR-7 HTTP message implementations.'
 repo_url: 'https://github.com/zendframework/zend-diactoros'
-copyright: 'Copyright (c) 2016-2018 <a href="https://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 docs_dir: docs/book
 site_dir: docs/html
 pages:
-  - index.md
+  - Home: index.md
   - Overview: v2/overview.md
   - Installation: v2/install.md
   - Usage: v2/usage.md


### PR DESCRIPTION
* copyright notice is no longer needed, because the template already contains this information
* the site description is synchronised with the documentation overview
* the name for the entry page is needed to eliminate the [first wrong / duplicate entry](https://github.com/zendframework/zf-mkdoc-theme/issues/48)
