### PR TITLE
Headers with value 0 being stripped out. Previous bugfix caused all headers to be accepted.

### DIFF
--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -35,19 +35,21 @@ function marshalHeadersFromSapi(array $server) : array
             }
         }
 
-        if ($value && strpos($key, 'HTTP_') === 0) {
+        if ($value === '') {
+            continue;
+        }
+
+        if (strpos($key, 'HTTP_') === 0) {
             $name = strtr(strtolower(substr($key, 5)), '_', '-');
             $headers[$name] = $value;
             continue;
         }
 
-        if ($value && strpos($key, 'CONTENT_') === 0) {
+        if (strpos($key, 'CONTENT_') === 0) {
             $name = 'content-' . strtolower(substr($key, 8));
             $headers[$name] = $value;
             continue;
         }
-
-        $headers[$key] = $value;
     }
 
     return $headers;


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
```
$ch = curl_init();
curl_setopt($ch, CURLOPT_URL, 'http://xxx.xxx.xxx');
curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH");
curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
curl_setopt($ch, CURLOPT_HEADER, true);
curl_setopt($ch, CURLOPT_HTTPHEADER, ["Upload-Offset: 0"]);
curl_exec($ch);
```
  - [x] Detail the original, incorrect behavior.
The header `Upload-Offset` is being stripped. (Any header with value "0")
The value was being used in a conditional.  To test `!!("0") === false`.
Test was incorrect because the header was being stripped because it was not prefixed with `HTTP_`.
Relates to #347 #342 #344 
  - [x] Detail the new, expected behavior.
Values with a string of "0" should be accepted
Test passes with proper header formation.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.