### PR TITLE
fix (Stream) Fix the fatal error on parameter 2

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -274,7 +274,7 @@ class Stream implements StreamInterface
             throw Exception\UnreadableStreamException::dueToConfiguration();
         }
 
-        $result = fread($this->resource, $length);
+        $result = fread($this->resource, (int)$length);
 
         if (false === $result) {
             throw Exception\UnreadableStreamException::dueToPhpError();


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [ x ] Are you fixing a bug?

When $length variable of Stream@read method is strictly a string (even if this one contains a number).