### PR TITLE
Fixed bug where all server vars are copied as headers

### DIFF
--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -35,19 +35,17 @@ function marshalHeadersFromSapi(array $server) : array
             }
         }
 
-        if ($value && strpos($key, 'HTTP_') === 0) {
+        if (strlen($value) && strpos($key, 'HTTP_') === 0) {
             $name = strtr(strtolower(substr($key, 5)), '_', '-');
             $headers[$name] = $value;
             continue;
         }
 
-        if ($value && strpos($key, 'CONTENT_') === 0) {
+        if (strlen($value) && strpos($key, 'CONTENT_') === 0) {
             $name = 'content-' . strtolower(substr($key, 8));
             $headers[$name] = $value;
             continue;
         }
-
-        $headers[$key] = $value;
     }
 
     return $headers;


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently: when creating a new request from globals
  - [x] Detail the original, incorrect behavior: all server vars are copied as headers
  - [x] Detail the new, expected behavior: only actual headers are extracted from $_SERVER
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
