### PR TITLE
PHPDBG is also a valid non-sapi environment

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -189,7 +189,7 @@ class UploadedFile implements UploadedFileInterface
 
         $sapi = PHP_SAPI;
         switch (true) {
-            case (empty($sapi) || 0 === strpos($sapi, 'cli') || ! $this->file):
+            case (empty($sapi) || 0 === strpos($sapi, 'cli') || 0 === strpos($sapi, 'phpdbg') || ! $this->file):
                 // Non-SAPI environment, or no filename present
                 $this->writeFile($targetPath);
                 break;


### PR DESCRIPTION
When calling `moveTo()` on `UploadedFile` in a `phpdbg` environment, `move_uplaoded_file()` is incorrectly called (and as expected fails). This adds `phpdbg` as a valid "non-SAPI" environment (Same as `cli`)