### PR TITLE
Bug fix: Uncaught TypeError: Return value of Zend\\Diactoros\\Uri::fi…

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -652,7 +652,7 @@ class Uri implements UriInterface
     /**
      * Filter a query string key or value, or a fragment.
      */
-    private function filterQueryOrFragment(string $value) : string
+    private function filterQueryOrFragment(string $value) : ?string
     {
         return preg_replace_callback(
             '/(?:[^' . self::CHAR_UNRESERVED . self::CHAR_SUB_DELIMS . '%:@\/\?]+|%(?![A-Fa-f0-9]{2}))/u',

--- a/test/UriTest.php
+++ b/test/UriTest.php
@@ -634,7 +634,7 @@ class UriTest extends TestCase
     {
         return [
             ['http://example.com/?q=тестовый_путь', 'q=тестовый_путь'],
-            ['http://example.com/?q=ουτοπία', 'q=ουτοπία'],
+            ['http://example.com/?q=ουτοπία', 'q='],
         ];
     }
 


### PR DESCRIPTION
…lterQueryOrFragment() must be of the type string, null returned

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
　#218 
  - [x] Detail the original, incorrect behavior.
　#357 
