### PR TITLE
Modify detection of HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#363](https://github.com/zendframework/zend-diactoros/issues/363) modifies detection of HTTPS schemas via the `$_SERVER['HTTPS']` value
+  such that an empty HTTPS-key will result in a scheme of `http` and not
+  `https`.
 
 ## 2.1.2 - 2019-04-29
 

--- a/src/functions/marshal_uri_from_sapi.php
+++ b/src/functions/marshal_uri_from_sapi.php
@@ -168,7 +168,7 @@ function marshalUriFromSapi(array $server, array $headers) : Uri
             ));
         }
 
-        return 'off' !== strtolower($https);
+        return 'on' === strtolower($https);
     };
     if (array_key_exists('HTTPS', $server)) {
         $https = $marshalHttpsValue($server['HTTPS']);

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -24,7 +24,7 @@ class MarshalUriFromSapiTest extends TestCase
         $server = [
             'HTTPS' => $httpsValue,
             'SERVER_NAME' => 'localhost',
-            'SERVER_PORT'=>'80',
+            'SERVER_PORT' => '80',
             'SERVER_ADDR' => '172.22.0.4',
             'REMOTE_PORT' => '36852',
             'REMOTE_ADDR' => '172.22.0.1',

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types = 1);
+
+namespace ZendTest\Diactoros\functions;
+
+use PHPUnit\Framework\TestCase;
+use function Zend\Diactoros\marshalUriFromSapi;
+
+class MarshalUriFromSapiTest extends TestCase
+{
+    /** @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider */
+    public function testReturnsUrlWithCorrectHttpSchemeFromArrays(string $httpsValue, string $expectedScheme) : void
+    {
+        $server = [
+            "HTTPS" => $httpsValue,
+            "SERVER_NAME"=> "localhost",
+            "SERVER_PORT"=>"80",
+            "SERVER_ADDR"=> "172.22.0.4",
+            "REMOTE_PORT"=> "36852",
+            "REMOTE_ADDR" =>  "172.22.0.1",
+            "SERVER_SOFTWARE" =>  "nginx/1.11.8",
+            "GATEWAY_INTERFACE" =>  "CGI/1.1",
+            "SERVER_PROTOCOL" =>  "HTTP/1.1",
+            "DOCUMENT_ROOT" => "/var/www/public",
+            "DOCUMENT_URI" => "/index.php",
+            "REQUEST_URI" =>  "/api/messagebox-schema",
+            "PATH_TRANSLATED" => "/var/www/public",
+            "PATH_INFO" => "",
+            "SCRIPT_NAME" => "/index.php",
+            "CONTENT_LENGTH" => "",
+            "CONTENT_TYPE" => "",
+            "REQUEST_METHOD" => "GET",
+            "QUERY_STRING" => "",
+            "SCRIPT_FILENAME" => "/var/www/public/index.php",
+            "FCGI_ROLE" => "RESPONDER",
+            "PHP_SELF" => "/index.php",
+        ];
+
+        $headers = [
+            "HTTP_COOKIE" => '',
+            "HTTP_ACCEPT_LANGUAGE" => "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+            "HTTP_ACCEPT_ENCODING" => "gzip, deflate, br",
+            "HTTP_REFERER" => "http://localhost:8080/index.html",
+            "HTTP_USER_AGENT" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36",
+            "HTTP_ACCEPT" => "application/json,*/*",
+            "HTTP_CONNECTION" => "keep-alive",
+            "HTTP_HOST" => "localhost:8080",
+        ];
+
+        $url = marshalUriFromSapi($server, $headers);
+
+        self::assertSame($expectedScheme, $url->getScheme());
+    }
+
+    public function returnsUrlWithCorrectHttpSchemeFromArraysProvider() : array
+    {
+        return [
+            'on-lowercase' => ['on', 'https'],
+            'on-uppercase' => ['ON', 'https'],
+            'off-lowercase' => ['off', 'http'],
+            'off-mixed-case' => ['oFf', 'http'],
+            'neither-on-nor-off' => ['foo', 'http'],
+            'empty' => ['', 'http'],
+        ];
+    }
+}

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
@@ -14,43 +14,47 @@ use function Zend\Diactoros\marshalUriFromSapi;
 
 class MarshalUriFromSapiTest extends TestCase
 {
-    /** @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider */
+    /**
+     * @param string $httpsValue
+     * @param string $expectedScheme
+     * @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider
+     */
     public function testReturnsUrlWithCorrectHttpSchemeFromArrays(string $httpsValue, string $expectedScheme) : void
     {
         $server = [
-            "HTTPS" => $httpsValue,
-            "SERVER_NAME"=> "localhost",
-            "SERVER_PORT"=>"80",
-            "SERVER_ADDR"=> "172.22.0.4",
-            "REMOTE_PORT"=> "36852",
-            "REMOTE_ADDR" =>  "172.22.0.1",
-            "SERVER_SOFTWARE" =>  "nginx/1.11.8",
-            "GATEWAY_INTERFACE" =>  "CGI/1.1",
-            "SERVER_PROTOCOL" =>  "HTTP/1.1",
-            "DOCUMENT_ROOT" => "/var/www/public",
-            "DOCUMENT_URI" => "/index.php",
-            "REQUEST_URI" =>  "/api/messagebox-schema",
-            "PATH_TRANSLATED" => "/var/www/public",
-            "PATH_INFO" => "",
-            "SCRIPT_NAME" => "/index.php",
-            "CONTENT_LENGTH" => "",
-            "CONTENT_TYPE" => "",
-            "REQUEST_METHOD" => "GET",
-            "QUERY_STRING" => "",
-            "SCRIPT_FILENAME" => "/var/www/public/index.php",
-            "FCGI_ROLE" => "RESPONDER",
-            "PHP_SELF" => "/index.php",
+            'HTTPS' => $httpsValue,
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT'=>'80',
+            'SERVER_ADDR' => '172.22.0.4',
+            'REMOTE_PORT' => '36852',
+            'REMOTE_ADDR' => '172.22.0.1',
+            'SERVER_SOFTWARE' => 'nginx/1.11.8',
+            'GATEWAY_INTERFACE' => 'CGI/1.1',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'DOCUMENT_ROOT' => '/var/www/public',
+            'DOCUMENT_URI' => '/index.php',
+            'REQUEST_URI' => '/api/messagebox-schema',
+            'PATH_TRANSLATED' => '/var/www/public',
+            'PATH_INFO' => '',
+            'SCRIPT_NAME' => '/index.php',
+            'CONTENT_LENGTH' => '',
+            'CONTENT_TYPE' => '',
+            'REQUEST_METHOD' => 'GET',
+            'QUERY_STRING' => '',
+            'SCRIPT_FILENAME' => '/var/www/public/index.php',
+            'FCGI_ROLE' => 'RESPONDER',
+            'PHP_SELF' => '/index.php',
         ];
 
         $headers = [
-            "HTTP_COOKIE" => '',
-            "HTTP_ACCEPT_LANGUAGE" => "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
-            "HTTP_ACCEPT_ENCODING" => "gzip, deflate, br",
-            "HTTP_REFERER" => "http://localhost:8080/index.html",
-            "HTTP_USER_AGENT" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36",
-            "HTTP_ACCEPT" => "application/json,*/*",
-            "HTTP_CONNECTION" => "keep-alive",
-            "HTTP_HOST" => "localhost:8080",
+            'HTTP_COOKIE' => '',
+            'HTTP_ACCEPT_LANGUAGE' => 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7',
+            'HTTP_ACCEPT_ENCODING' => 'gzip, deflate, br',
+            'HTTP_REFERER' => 'http://localhost:8080/index.html',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36',
+            'HTTP_ACCEPT' => 'application/json,*/*',
+            'HTTP_CONNECTION' => 'keep-alive',
+            'HTTP_HOST' => 'localhost:8080',
         ];
 
         $url = marshalUriFromSapi($server, $headers);


### PR DESCRIPTION
This modifies the detection of HTTPS by checking whether the lower-case value of the HTTPS-key of the server variable equals 'on'. Before that checked whether the value did *not* match 'off' which meant that the nginx-default for non-HTTPS connections (which, according to the [documentation](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_https) is an empty string) did in fact match and returned that the connection *is* encrypted.

This fixes #362

Provide a narrative description of what you are trying to accomplish: See #362 

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
