### PR TITLE
Apply #363 (detection of HTTPS) on v1 (LTS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.8.7 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#364](https://github.com/zendframework/zend-diactoros/issues/364) modifies detection of HTTPS schemas via the `$_SERVER['HTTPS']` value
+  such that an empty HTTPS-key will result in a scheme of `http` and not
+  `https`.
+
 ## 1.8.6 - 2018-09-05
 
 ### Added

--- a/src/functions/marshal_uri_from_sapi.php
+++ b/src/functions/marshal_uri_from_sapi.php
@@ -171,7 +171,7 @@ function marshalUriFromSapi(array $server, array $headers)
     } else {
         $https = false;
     }
-    if (($https && 'off' !== strtolower($https))
+    if (($https && 'on' === strtolower($https))
         || strtolower($getHeaderFromArray('x-forwarded-proto', $headers, false)) === 'https'
     ) {
         $scheme = 'https';

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -295,7 +295,7 @@ class ServerRequestFactoryTest extends TestCase
         $request = $request->withHeader('Host', 'example.com');
 
         $server  = [
-            $param => true,
+            $param => 'on',
         ];
 
         $uri = marshalUriFromSapi($server, $request->getHeaders());

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
@@ -12,43 +12,47 @@ use function Zend\Diactoros\marshalUriFromSapi;
 
 class MarshalUriFromSapiTest extends TestCase
 {
-    /** @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider */
+    /**
+     * @param string $httpsValue
+     * @param string $expectedScheme
+     * @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider
+     */
     public function testReturnsUrlWithCorrectHttpSchemeFromArrays(string $httpsValue, string $expectedScheme) : void
     {
         $server = [
-            "HTTPS" => $httpsValue,
-            "SERVER_NAME"=> "localhost",
-            "SERVER_PORT"=>"80",
-            "SERVER_ADDR"=> "172.22.0.4",
-            "REMOTE_PORT"=> "36852",
-            "REMOTE_ADDR" =>  "172.22.0.1",
-            "SERVER_SOFTWARE" =>  "nginx/1.11.8",
-            "GATEWAY_INTERFACE" =>  "CGI/1.1",
-            "SERVER_PROTOCOL" =>  "HTTP/1.1",
-            "DOCUMENT_ROOT" => "/var/www/public",
-            "DOCUMENT_URI" => "/index.php",
-            "REQUEST_URI" =>  "/api/messagebox-schema",
-            "PATH_TRANSLATED" => "/var/www/public",
-            "PATH_INFO" => "",
-            "SCRIPT_NAME" => "/index.php",
-            "CONTENT_LENGTH" => "",
-            "CONTENT_TYPE" => "",
-            "REQUEST_METHOD" => "GET",
-            "QUERY_STRING" => "",
-            "SCRIPT_FILENAME" => "/var/www/public/index.php",
-            "FCGI_ROLE" => "RESPONDER",
-            "PHP_SELF" => "/index.php",
+            'HTTPS' => $httpsValue,
+            'SERVER_NAME' => 'localhost',
+            'SERVER_PORT'=>'80',
+            'SERVER_ADDR' => '172.22.0.4',
+            'REMOTE_PORT' => '36852',
+            'REMOTE_ADDR' => '172.22.0.1',
+            'SERVER_SOFTWARE' => 'nginx/1.11.8',
+            'GATEWAY_INTERFACE' => 'CGI/1.1',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'DOCUMENT_ROOT' => '/var/www/public',
+            'DOCUMENT_URI' => '/index.php',
+            'REQUEST_URI' => '/api/messagebox-schema',
+            'PATH_TRANSLATED' => '/var/www/public',
+            'PATH_INFO' => '',
+            'SCRIPT_NAME' => '/index.php',
+            'CONTENT_LENGTH' => '',
+            'CONTENT_TYPE' => '',
+            'REQUEST_METHOD' => 'GET',
+            'QUERY_STRING' => '',
+            'SCRIPT_FILENAME' => '/var/www/public/index.php',
+            'FCGI_ROLE' => 'RESPONDER',
+            'PHP_SELF' => '/index.php',
         ];
 
         $headers = [
-            "HTTP_COOKIE" => '',
-            "HTTP_ACCEPT_LANGUAGE" => "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
-            "HTTP_ACCEPT_ENCODING" => "gzip, deflate, br",
-            "HTTP_REFERER" => "http://localhost:8080/index.html",
-            "HTTP_USER_AGENT" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36",
-            "HTTP_ACCEPT" => "application/json,*/*",
-            "HTTP_CONNECTION" => "keep-alive",
-            "HTTP_HOST" => "localhost:8080",
+            'HTTP_COOKIE' => '',
+            'HTTP_ACCEPT_LANGUAGE' => 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7',
+            'HTTP_ACCEPT_ENCODING' => 'gzip, deflate, br',
+            'HTTP_REFERER' => 'http://localhost:8080/index.html',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36',
+            'HTTP_ACCEPT' => 'application/json,*/*',
+            'HTTP_CONNECTION' => 'keep-alive',
+            'HTTP_HOST' => 'localhost:8080',
         ];
 
         $url = marshalUriFromSapi($server, $headers);

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -17,7 +17,7 @@ class MarshalUriFromSapiTest extends TestCase
      * @param string $expectedScheme
      * @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider
      */
-    public function testReturnsUrlWithCorrectHttpSchemeFromArrays(string $httpsValue, string $expectedScheme) : void
+    public function testReturnsUrlWithCorrectHttpSchemeFromArrays($httpsValue, $expectedScheme)
     {
         $server = [
             'HTTPS' => $httpsValue,
@@ -60,7 +60,10 @@ class MarshalUriFromSapiTest extends TestCase
         self::assertSame($expectedScheme, $url->getScheme());
     }
 
-    public function returnsUrlWithCorrectHttpSchemeFromArraysProvider() : array
+    /**
+     * @return array
+     */
+    public function returnsUrlWithCorrectHttpSchemeFromArraysProvider()
     {
         return [
             'on-lowercase' => ['on', 'https'],

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -49,7 +49,7 @@ class MarshalUriFromSapiTest extends TestCase
             'HTTP_ACCEPT_LANGUAGE' => 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7',
             'HTTP_ACCEPT_ENCODING' => 'gzip, deflate, br',
             'HTTP_REFERER' => 'http://localhost:8080/index.html',
-            'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)',
             'HTTP_ACCEPT' => 'application/json,*/*',
             'HTTP_CONNECTION' => 'keep-alive',
             'HTTP_HOST' => 'localhost:8080',

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Diactoros\functions;
+
+use PHPUnit\Framework\TestCase;
+use function Zend\Diactoros\marshalUriFromSapi;
+
+class MarshalUriFromSapiTest extends TestCase
+{
+    /** @dataProvider returnsUrlWithCorrectHttpSchemeFromArraysProvider */
+    public function testReturnsUrlWithCorrectHttpSchemeFromArrays(string $httpsValue, string $expectedScheme) : void
+    {
+        $server = [
+            "HTTPS" => $httpsValue,
+            "SERVER_NAME"=> "localhost",
+            "SERVER_PORT"=>"80",
+            "SERVER_ADDR"=> "172.22.0.4",
+            "REMOTE_PORT"=> "36852",
+            "REMOTE_ADDR" =>  "172.22.0.1",
+            "SERVER_SOFTWARE" =>  "nginx/1.11.8",
+            "GATEWAY_INTERFACE" =>  "CGI/1.1",
+            "SERVER_PROTOCOL" =>  "HTTP/1.1",
+            "DOCUMENT_ROOT" => "/var/www/public",
+            "DOCUMENT_URI" => "/index.php",
+            "REQUEST_URI" =>  "/api/messagebox-schema",
+            "PATH_TRANSLATED" => "/var/www/public",
+            "PATH_INFO" => "",
+            "SCRIPT_NAME" => "/index.php",
+            "CONTENT_LENGTH" => "",
+            "CONTENT_TYPE" => "",
+            "REQUEST_METHOD" => "GET",
+            "QUERY_STRING" => "",
+            "SCRIPT_FILENAME" => "/var/www/public/index.php",
+            "FCGI_ROLE" => "RESPONDER",
+            "PHP_SELF" => "/index.php",
+        ];
+
+        $headers = [
+            "HTTP_COOKIE" => '',
+            "HTTP_ACCEPT_LANGUAGE" => "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+            "HTTP_ACCEPT_ENCODING" => "gzip, deflate, br",
+            "HTTP_REFERER" => "http://localhost:8080/index.html",
+            "HTTP_USER_AGENT" => "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/67.0.3396.99 Chrome/67.0.3396.99 Safari/537.36",
+            "HTTP_ACCEPT" => "application/json,*/*",
+            "HTTP_CONNECTION" => "keep-alive",
+            "HTTP_HOST" => "localhost:8080",
+        ];
+
+        $url = marshalUriFromSapi($server, $headers);
+
+        self::assertSame($expectedScheme, $url->getScheme());
+    }
+
+    public function returnsUrlWithCorrectHttpSchemeFromArraysProvider() : array
+    {
+        return [
+            'on-lowercase' => ['on', 'https'],
+            'on-uppercase' => ['ON', 'https'],
+            'off-lowercase' => ['off', 'http'],
+            'off-mixed-case' => ['oFf', 'http'],
+            'neither-on-nor-off' => ['foo', 'http'],
+            'empty' => ['', 'http'],
+        ];
+    }
+}

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -22,7 +22,7 @@ class MarshalUriFromSapiTest extends TestCase
         $server = [
             'HTTPS' => $httpsValue,
             'SERVER_NAME' => 'localhost',
-            'SERVER_PORT'=>'80',
+            'SERVER_PORT' => '80',
             'SERVER_ADDR' => '172.22.0.4',
             'REMOTE_PORT' => '36852',
             'REMOTE_ADDR' => '172.22.0.1',


### PR DESCRIPTION
As zend-diactoros v1 is still LTS we should provide the hotfix also in that branch.
I've ported @heiglandreas commits with changes to work on v1.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

/cc @heiglandreas @weierophinney 
