### PR TITLE
Fixed failing tests: set user agent on load external content

### DIFF
--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -61,6 +61,7 @@ class ResponseTest extends TestCase
                     'http' => [
                         'method'  => 'GET',
                         'timeout' => 30,
+                        'user_agent' => 'PHP',
                     ],
                 ]
             )


### PR DESCRIPTION
For a while tests were failing on the build. Here is the simple fix