### PR TITLE
Refactor fetching iana http status codes to use caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 doc/html/
 vendor/
 zf-mkdoc-theme/
+/test/TestAsset/.cache/
 phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 cache:
   directories:
     - $HOME/.composer/cache
+    - test/TestAsset/.cache # Cache archives are currently set to expire after 28 days by default
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "psr/http-message": "^1.0"
   },
   "require-dev": {
+    "ext-curl": "*",
     "ext-dom": "*",
     "ext-libxml": "*",
     "http-interop/http-factory-tests": "^0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3371a4353461b951e43e35fe472b59e",
+    "content-hash": "1460d979a214badb7a4393d3b770d676",
     "packages": [
         {
             "name": "psr/http-factory",
@@ -678,8 +678,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -726,8 +726,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -817,8 +817,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Utility class for timing",
@@ -948,8 +948,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -1733,6 +1733,7 @@
         "php": "^7.1"
     },
     "platform-dev": {
+        "ext-curl": "*",
         "ext-dom": "*",
         "ext-libxml": "*"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
     </filter>
 
     <php>
+        <env name="ALWAYS_REFRESH_IANA_HTTP_STATUS_CODES" value="false"/>
         <const name="REQUEST_FACTORY" value="Zend\Diactoros\RequestFactory"/>
         <const name="RESPONSE_FACTORY" value="Zend\Diactoros\ResponseFactory"/>
         <const name="SERVER_REQUEST_FACTORY" value="Zend\Diactoros\ServerRequestFactory"/>

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -21,7 +21,6 @@ use function curl_exec;
 use function curl_getinfo;
 use function curl_init;
 use function curl_setopt;
-use function defined;
 use function file_exists;
 use function file_put_contents;
 use function gmdate;

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2019 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
  */
 
@@ -16,10 +16,25 @@ use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 
+use function curl_close;
+use function curl_exec;
+use function curl_getinfo;
+use function curl_init;
+use function curl_setopt;
+use function defined;
+use function file_exists;
+use function file_put_contents;
+use function gmdate;
 use function in_array;
-use function libxml_set_streams_context;
 use function preg_match;
-use function stream_context_create;
+use function sprintf;
+use function strtotime;
+
+use const CURLINFO_HTTP_CODE;
+use const CURLOPT_HTTPHEADER;
+use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_TIMEOUT;
+use const LOCK_EX;
 
 class ResponseTest extends TestCase
 {
@@ -51,27 +66,67 @@ class ResponseTest extends TestCase
         $this->assertSame('Unprocessable Entity', $response->getReasonPhrase());
     }
 
+    private function fetchIanaStatusCodes() : DOMDocument
+    {
+        $updated = null;
+        $ianaHttpStatusCodesFile = __DIR__ . '/TestAsset/.cache/http-status-codes.xml';
+        $ianaHttpStatusCodes = null;
+        if (file_exists($ianaHttpStatusCodesFile)) {
+            $ianaHttpStatusCodes = new DOMDocument();
+            $ianaHttpStatusCodes->load($ianaHttpStatusCodesFile);
+            if (! $ianaHttpStatusCodes->relaxNGValidate(__DIR__ . '/TestAsset/http-status-codes.rng')) {
+                $ianaHttpStatusCodes = null;
+            }
+        }
+        if ($ianaHttpStatusCodes) {
+            if (! getenv('ALWAYS_REFRESH_IANA_HTTP_STATUS_CODES')) {
+                // use cached codes
+                return $ianaHttpStatusCodes;
+            }
+            $xpath = new DOMXPath($ianaHttpStatusCodes);
+            $xpath->registerNamespace('ns', 'http://www.iana.org/assignments');
+            $updated = $xpath->query('//ns:updated')->item(0)->nodeValue;
+            $updated = strtotime($updated);
+        }
+
+        $ch = curl_init('https://www.iana.org/assignments/http-status-codes/http-status-codes.xml');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'PHP Curl');
+        if ($updated) {
+            $ifModifiedSince = sprintf(
+                'If-Modified-Since: %s',
+                gmdate('D, d M Y H:i:s \G\M\T', $updated)
+            );
+            curl_setopt($ch, CURLOPT_HTTPHEADER, [$ifModifiedSince]);
+        }
+        $response = curl_exec($ch);
+        $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($responseCode === 304 && $ianaHttpStatusCodes) {
+            // status codes did not change
+            return $ianaHttpStatusCodes;
+        }
+
+        if ($responseCode === 200) {
+            $downloadedIanaHttpStatusCodes = new DOMDocument();
+            $downloadedIanaHttpStatusCodes->loadXML($response);
+            if ($downloadedIanaHttpStatusCodes->relaxNGValidate(__DIR__ . '/TestAsset/http-status-codes.rng')) {
+                file_put_contents($ianaHttpStatusCodesFile, $response, LOCK_EX);
+                return $downloadedIanaHttpStatusCodes;
+            }
+        }
+        if ($ianaHttpStatusCodes) {
+            // return cached codes if available
+            return $ianaHttpStatusCodes;
+        }
+        self::fail('Unable to retrieve IANA response status codes due to timeout or invalid XML');
+    }
+
     public function ianaCodesReasonPhrasesProvider()
     {
-        $ianaHttpStatusCodes = new DOMDocument();
-
-        libxml_set_streams_context(
-            stream_context_create(
-                [
-                    'http' => [
-                        'method'  => 'GET',
-                        'timeout' => 30,
-                        'user_agent' => 'PHP',
-                    ],
-                ]
-            )
-        );
-
-        $ianaHttpStatusCodes->load('https://www.iana.org/assignments/http-status-codes/http-status-codes.xml');
-
-        if (! $ianaHttpStatusCodes->relaxNGValidate(__DIR__ . '/TestAsset/http-status-codes.rng')) {
-            self::fail('Unable to retrieve IANA response status codes due to timeout or invalid XML');
-        }
+        $ianaHttpStatusCodes = $this->fetchIanaStatusCodes();
 
         $ianaCodesReasonPhrases = [];
 


### PR DESCRIPTION
Refactored iana status codes test provider to use locally cached file instead of downloading them on each tests run.

Also fixed failing tests, replaces #366 
