### PR TITLE
use shorter expressions in functions

### DIFF
--- a/src/functions/create_uploaded_file.php
+++ b/src/functions/create_uploaded_file.php
@@ -33,7 +33,7 @@ function createUploadedFile(array $spec) : UploadedFile
         $spec['tmp_name'],
         $spec['size'],
         $spec['error'],
-        isset($spec['name']) ? $spec['name'] : null,
-        isset($spec['type']) ? $spec['type'] : null
+        $spec['name'] ?? null,
+        $spec['type'] ?? null
     );
 }

--- a/src/functions/marshal_method_from_sapi.php
+++ b/src/functions/marshal_method_from_sapi.php
@@ -14,5 +14,5 @@ namespace Zend\Diactoros;
  */
 function marshalMethodFromSapi(array $server) : string
 {
-    return isset($server['REQUEST_METHOD']) ? $server['REQUEST_METHOD'] : 'GET';
+    return $server['REQUEST_METHOD'] ?? 'GET';
 }

--- a/src/functions/marshal_uri_from_sapi.php
+++ b/src/functions/marshal_uri_from_sapi.php
@@ -132,19 +132,19 @@ function marshalUriFromSapi(array $server, array $headers) : Uri
     $marshalRequestPath = function (array $server) : string {
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
-        $iisUrlRewritten = array_key_exists('IIS_WasUrlRewritten', $server) ? $server['IIS_WasUrlRewritten'] : null;
-        $unencodedUrl    = array_key_exists('UNENCODED_URL', $server) ? $server['UNENCODED_URL'] : '';
+        $iisUrlRewritten = $server['IIS_WasUrlRewritten'] ?? null;
+        $unencodedUrl    = $server['UNENCODED_URL'] ?? '';
         if ('1' === $iisUrlRewritten && ! empty($unencodedUrl)) {
             return $unencodedUrl;
         }
 
-        $requestUri = array_key_exists('REQUEST_URI', $server) ? $server['REQUEST_URI'] : null;
+        $requestUri = $server['REQUEST_URI'] ?? null;
 
         if ($requestUri !== null) {
             return preg_replace('#^[^/:]+://[^/]+#', '', $requestUri);
         }
 
-        $origPathInfo = array_key_exists('ORIG_PATH_INFO', $server) ? $server['ORIG_PATH_INFO'] : null;
+        $origPathInfo = $server['ORIG_PATH_INFO'] ?? null;
         if (empty($origPathInfo)) {
             return '/';
         }

--- a/src/functions/normalize_uploaded_files.php
+++ b/src/functions/normalize_uploaded_files.php
@@ -49,8 +49,8 @@ function normalizeUploadedFiles(array $files) : array
                     $tmpNameTree[$key],
                     $sizeTree[$key],
                     $errorTree[$key],
-                    isset($nameTree[$key]) ? $nameTree[$key] : null,
-                    isset($typeTree[$key]) ? $typeTree[$key] : null
+                    $nameTree[$key] ?? null,
+                    $typeTree[$key] ?? null
                 );
                 continue;
             }
@@ -58,8 +58,8 @@ function normalizeUploadedFiles(array $files) : array
                 'tmp_name' => $tmpNameTree[$key],
                 'size' => $sizeTree[$key],
                 'error' => $errorTree[$key],
-                'name' => isset($nameTree[$key]) ? $nameTree[$key] : null,
-                'type' => isset($typeTree[$key]) ? $typeTree[$key] : null
+                'name' => $nameTree[$key] ?? null,
+                'type' => $typeTree[$key] ?? null,
             ]);
         }
         return $normalized;
@@ -96,8 +96,8 @@ function normalizeUploadedFiles(array $files) : array
             $files['tmp_name'],
             $files['size'],
             $files['error'],
-            isset($files['name']) ? $files['name'] : null,
-            isset($files['type']) ? $files['type'] : null
+            $files['name'] ?? null,
+            $files['type'] ?? null
         );
     };
 


### PR DESCRIPTION
min requirement is now php-7.1 => replace long expressions with equivalent shorter ones (and faster when `array_key_exists` is involved):

- REPLACE `isset($arr[$key]) ? $arr[$key] : $default` WITH `$arr[$key] ?? $default` 
- REPLACE `array_key_exists($key, $arr) ? $arr[$key] : null` WITH `$arr[$key] ?? null`

if an array_key_exists but the associated value is NULL and we use NULL when that key does not exists, the result is equivalent to just calling `isset` and use NULL if not isset, For what is worth...micro-opt...`isset` being as a language construct is faster than the `array_key_exist` func.

The case for:
```php
$unencodedUrl    = $server['UNENCODED_URL'] ?? '';
```
later `! empty($unencodedUrl)` is called so `null` and the empty string `''` are both falsy values anyway and lead to the same result.