### PR TITLE
Hotfix: marshalHeadersFromSapi function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.1.4 - TBD
+## 2.1.4 - 2019-10-08
 
 ### Added
 
@@ -22,7 +22,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#370](https://github.com/zendframework/zend-diactoros/pull/370) updates `Zend\Diactoros\marshalHeadersFromSapi()` to ensure all underscores in header name keys are converted to dashes (fixing issues with header names such as `CONTENT_SECURITY_POLICY`, which would previously resolve improperly to `content-security_policy`).
+
+- [#370](https://github.com/zendframework/zend-diactoros/pull/370) updates `Zend\Diactoros\marshalHeadersFromSapi()` to ignore header names from the `$server` array that resolve to integers; previously, it would raise a fatal error.
 
 ## 2.1.3 - 2019-07-10
 

--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Zend\Diactoros;
 
 use function array_key_exists;
+use function is_string;
 use function strpos;
 use function strtolower;
 use function strtr;
@@ -23,6 +24,10 @@ function marshalHeadersFromSapi(array $server) : array
 {
     $headers = [];
     foreach ($server as $key => $value) {
+        if (! is_string($key)) {
+            continue;
+        }
+
         // Apache prefixes environment variables with REDIRECT_
         // if they are added by rewrite rules
         if (strpos($key, 'REDIRECT_') === 0) {

--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -45,7 +45,7 @@ function marshalHeadersFromSapi(array $server) : array
         }
 
         if (strpos($key, 'HTTP_') === 0) {
-            $name = strtr(strtolower(substr($key, 5)), '_', '-');
+            $name = str_replace('_', '-', strtolower(substr($key, 5)));
             $headers[$name] = $value;
             continue;
         }

--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -28,6 +28,10 @@ function marshalHeadersFromSapi(array $server) : array
             continue;
         }
 
+        if ($value === '') {
+            continue;
+        }
+
         // Apache prefixes environment variables with REDIRECT_
         // if they are added by rewrite rules
         if (strpos($key, 'REDIRECT_') === 0) {
@@ -38,10 +42,6 @@ function marshalHeadersFromSapi(array $server) : array
             if (array_key_exists($key, $server)) {
                 continue;
             }
-        }
-
-        if ($value === '') {
-            continue;
         }
 
         if (strpos($key, 'HTTP_') === 0) {

--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -45,13 +45,13 @@ function marshalHeadersFromSapi(array $server) : array
         }
 
         if (strpos($key, 'HTTP_') === 0) {
-            $name = str_replace('_', '-', strtolower(substr($key, 5)));
+            $name = strtr(strtolower(substr($key, 5)), '_', '-');
             $headers[$name] = $value;
             continue;
         }
 
         if (strpos($key, 'CONTENT_') === 0) {
-            $name = str_replace('_', '-', strtolower($key));
+            $name = strtr(strtolower($key), '_', '-');
             $headers[$name] = $value;
             continue;
         }

--- a/src/functions/marshal_headers_from_sapi.php
+++ b/src/functions/marshal_headers_from_sapi.php
@@ -51,7 +51,7 @@ function marshalHeadersFromSapi(array $server) : array
         }
 
         if (strpos($key, 'CONTENT_') === 0) {
-            $name = 'content-' . strtolower(substr($key, 8));
+            $name = str_replace('_', '-', strtolower($key));
             $headers[$name] = $value;
             continue;
         }

--- a/test/functions/MarshalHeadersFromSapiTest.php
+++ b/test/functions/MarshalHeadersFromSapiTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Diactoros\functions;
+
+use PHPUnit\Framework\TestCase;
+
+use function Zend\Diactoros\marshalHeadersFromSapi;
+
+class MarshalHeadersFromSapiTest extends TestCase
+{
+    public function testReturnsHeaders() : void
+    {
+        $server = [
+            'REDIRECT_CONTENT_FOO' => 'redirect-foo',
+            'CONTENT_FOO' => null,
+            'REDIRECT_CONTENT_BAR' => 'redirect-bar',
+            'CONTENT_BAR' => '',
+            'REDIRECT_CONTENT_BAZ' => 'redirect-baz',
+            'CONTENT_BAZ' => 'baz',
+            'REDIRECT_CONTENT_VAR' => 'redirect-var',
+
+            'REDIRECT_HTTP_ABC' => 'redirect-abc',
+            'HTTP_ABC' => null,
+            'REDIRECT_HTTP_DEF' => 'redirect-def',
+            'HTTP_DEF' => '',
+            'REDIRECT_HTTP_GHI' => 'redirect-ghi',
+            'HTTP_GHI' => 'ghi',
+            'REDIRECT_HTTP_JKL' => 'redirect-jkl',
+
+            'HTTP_TEST_MNO' => 'mno',
+            'HTTP_TEST_PQR' => '',
+            'HTTP_TEST_STU' => null,
+            'CONTENT_TEST_VW' => 'vw',
+            'CONTENT_TEST_XY' => '',
+            'CONTENT_TEST_ZZ' => null,
+
+            123 => 'integer',
+        ];
+
+        $expectedHeaders = [
+            'content-foo' => null,
+            'content-baz' => 'baz',
+            'content-var' => 'redirect-var',
+
+            'abc' => null,
+            'ghi' => 'ghi',
+            'jkl' => 'redirect-jkl',
+
+            'test-mno' => 'mno',
+            'test-stu' => null,
+            'content-test-vw' => 'vw',
+            'content-test-zz' => null,
+        ];
+
+        $headers = marshalHeadersFromSapi($server);
+
+        self::assertSame($expectedHeaders, $headers);
+    }
+}


### PR DESCRIPTION
- integer keys should be ignored
- _ should be changed to - in key (also for CONTENT_* headers)

Fixes #369 

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
