### PR TITLE
`X-Forwarded-Host` for `marshalUriFromSapi`

### DIFF
--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -78,8 +78,12 @@ class MarshalUriFromSapiTest extends TestCase
     /**
      * @dataProvider returnsUrlWithCorrectSchemeAndHostFromArrays
      */
-    public function testReturnsUrlWithCorrectSchemeAndHostFromArrays(string $expectedScheme, string $expectedHost, array $server, array $headers) : void
-    {
+    public function testReturnsUrlWithCorrectSchemeAndHostFromArrays(
+        string $expectedScheme,
+        string $expectedHost,
+        array $server,
+        array $headers
+    ) : void {
         $uri = marshalUriFromSapi($server, $headers);
         self::assertSame($expectedScheme, $uri->getScheme());
         self::assertSame($expectedHost, $uri->getHost());

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -102,7 +102,7 @@ class MarshalUriFromSapiTest extends TestCase
                 [
                     'SERVER_NAME' => 'localhost',
                 ],
-                ['X-Forwarded-Host' => 'example.org'],
+                ['X-Forwarded-Host' => 'example.org', 'Host' => 'localhost'],
             ],
         ];
     }

--- a/test/functions/MarshalUriFromSapiTest.php
+++ b/test/functions/MarshalUriFromSapiTest.php
@@ -74,4 +74,36 @@ class MarshalUriFromSapiTest extends TestCase
             'empty' => ['', 'http'],
         ];
     }
+
+    /**
+     * @dataProvider returnsUrlWithCorrectSchemeAndHostFromArrays
+     */
+    public function testReturnsUrlWithCorrectSchemeAndHostFromArrays(string $expectedScheme, string $expectedHost, array $server, array $headers) : void
+    {
+        $uri = marshalUriFromSapi($server, $headers);
+        self::assertSame($expectedScheme, $uri->getScheme());
+        self::assertSame($expectedHost, $uri->getHost());
+    }
+
+    public function returnsUrlWithCorrectSchemeAndHostFromArrays() : array
+    {
+        return [
+            'x-forwarded-proto' => [
+                'https',
+                'localhost',
+                [
+                    'SERVER_NAME' => 'localhost',
+                ],
+                ['X-Forwarded-Proto' => 'https'],
+            ],
+            'x-forwarded-host' => [
+                'http',
+                'example.org',
+                [
+                    'SERVER_NAME' => 'localhost',
+                ],
+                ['X-Forwarded-Host' => 'example.org'],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Hey guys,

we are using NGINX+ with loadbalancing to multiple servers which are not aware of external domain names (for reasons).
However, NGINX provides `X-Forwarded-Host` header to those upstream servers to tell them which external domain was called.

I've added an example on what I would like to expect (even tho that `X-Forwarded-Proto` is being handled for the `https` scheme).

Tell me what you think.