### PR TITLE
Make UploadedFile Extend SplFileInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,33 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.2.0 - TBD
+## 2.2.1 - TBD
 
 ### Added
 
 - [#376](https://github.com/zendframework/zend-diactoros/pull/376) adds support for using the X-Forwarded-Host header for determining the originally requested host name when marshaling the server request.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
+## 2.2.0  - 2019-11-08
+
+### Added
+
+- [#377](https://github.com/zendframework/zend-diactoros/issues/377) enables UploadedFile to stand in and be used as an SplFileInfo object.
 
 ### Changed
 
@@ -641,7 +663,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#293](https://github.com/zendframework/zend-diactoros/pull/293) updates
   `Uri::getHost()` to cast the value via `strtolower()` before returning it.
-  While this represents a change, it is fixing a bug in our implementation: 
+  While this represents a change, it is fixing a bug in our implementation:
   the PSR-7 specification for the method, which follows IETF RFC 3986 section
   3.2.2, requires that the host name be normalized to lowercase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#378](https://github.com/zendframework/zend-diactoros/pull/378) updates the `UploadedFile` class to extend `SplFileInfo`, allowing developers to make use of those features in their applications.
 
 ### Deprecated
 

--- a/docs/book/v2/api.md
+++ b/docs/book/v2/api.md
@@ -194,4 +194,6 @@ In most cases, you will not interact with the Stream object directly.
 and provides abstraction around a single uploaded file, including behavior for interacting with it
 as a stream or moving it to a filesystem location.
 
+Additionally, it extends PHP's build in `SplFileInfo` object in order to provide a compatible interface wherever such an object is needed.
+
 In most cases, you will only use the methods defined in the `UploadedFileInterface`.

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Zend\Diactoros;
 
+use SplFileInfo;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
@@ -35,7 +36,7 @@ use const UPLOAD_ERR_NO_TMP_DIR;
 use const UPLOAD_ERR_OK;
 use const UPLOAD_ERR_PARTIAL;
 
-class UploadedFile implements UploadedFileInterface
+class UploadedFile extends SplFileInfo implements UploadedFileInterface
 {
     const ERROR_MESSAGES = [
         UPLOAD_ERR_OK         => 'There is no error, the file uploaded with success',
@@ -102,9 +103,13 @@ class UploadedFile implements UploadedFileInterface
         if ($errorStatus === UPLOAD_ERR_OK) {
             if (is_string($streamOrFile)) {
                 $this->file = $streamOrFile;
+
+                parent::__construct($this->file);
             }
             if (is_resource($streamOrFile)) {
                 $this->stream = new Stream($streamOrFile);
+
+                parent::__construct($this->stream->getMetaData('uri'));
             }
 
             if (! $this->file && ! $this->stream) {

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use RuntimeException;
+use SplFileInfo;
 use Zend\Diactoros\Stream;
 use Zend\Diactoros\UploadedFile;
 
@@ -324,5 +325,14 @@ class UploadedFileTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($message);
         $uploadedFile->moveTo('/tmp/foo');
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-diactoros/pull/378
+     */
+    public function testExtendsSplFileInfo()
+    {
+        $uploaded = new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK);
+        $this->assertInstanceOf(SplFileInfo::class, $uploaded);
     }
 }


### PR DESCRIPTION
This is a new feature to make UploadedFile extend SplFileInfo which enables you to pass UploadedFile instances in places where SplFileInfo typehints are required and use SplFileInfo based methods to access information about the file while still having access to the additional UploadedFile interface.

This is primarily useful for populating models/entities directly from requests wherein a supplied value needs to be an instance of SplFileInfo and wherein a service or hook later may move the files into more appropriate places at time of persistence.
