### PR TITLE
Reverts extension of SplFileInfo

### DIFF
--- a/docs/book/v2/api.md
+++ b/docs/book/v2/api.md
@@ -194,6 +194,4 @@ In most cases, you will not interact with the Stream object directly.
 and provides abstraction around a single uploaded file, including behavior for interacting with it
 as a stream or moving it to a filesystem location.
 
-Additionally, it extends PHP's build in `SplFileInfo` object in order to provide a compatible interface wherever such an object is needed.
-
 In most cases, you will only use the methods defined in the `UploadedFileInterface`.

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Zend\Diactoros;
 
-use SplFileInfo;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
@@ -36,7 +35,7 @@ use const UPLOAD_ERR_NO_TMP_DIR;
 use const UPLOAD_ERR_OK;
 use const UPLOAD_ERR_PARTIAL;
 
-class UploadedFile extends SplFileInfo implements UploadedFileInterface
+class UploadedFile implements UploadedFileInterface
 {
     const ERROR_MESSAGES = [
         UPLOAD_ERR_OK         => 'There is no error, the file uploaded with success',
@@ -103,13 +102,9 @@ class UploadedFile extends SplFileInfo implements UploadedFileInterface
         if ($errorStatus === UPLOAD_ERR_OK) {
             if (is_string($streamOrFile)) {
                 $this->file = $streamOrFile;
-
-                parent::__construct($this->file);
             }
             if (is_resource($streamOrFile)) {
                 $this->stream = new Stream($streamOrFile);
-
-                parent::__construct($this->stream->getMetaData('uri'));
             }
 
             if (! $this->file && ! $this->stream) {

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -13,7 +13,6 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use RuntimeException;
-use SplFileInfo;
 use Zend\Diactoros\Stream;
 use Zend\Diactoros\UploadedFile;
 
@@ -325,14 +324,5 @@ class UploadedFileTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage($message);
         $uploadedFile->moveTo('/tmp/foo');
-    }
-
-    /**
-     * @see https://github.com/zendframework/zend-diactoros/pull/378
-     */
-    public function testExtendsSplFileInfo()
-    {
-        $uploaded = new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK);
-        $this->assertInstanceOf(SplFileInfo::class, $uploaded);
     }
 }


### PR DESCRIPTION
Post-release of 2.2.0, users discovered problems with `UploadedFile` extending `SplFileInfo`, particularly when a stream path is used to create the instance. Additionally, there are some differences with how `UploadedFileInterface` and `SplFileInfo` each define the return type for `getSize()`; the former allows nullification, while the latter does not, but allows raising an exception (something explicitly disallowed in PSR-7).

This patch reverts the code and documentation changes associated with the patch.