### PR TITLE
QA: update PHPUnit and tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "ext-libxml": "*",
     "http-interop/http-factory-tests": "^0.5.0",
     "php-http/psr7-integration-tests": "dev-master",
-    "phpunit/phpunit": "^7.0.2",
+    "phpunit/phpunit": "^7.5.18",
     "zendframework/zend-coding-standard": "~1.0.0"
   },
   "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28ba0e559d9869f93e5c425764efb3b7",
+    "content-hash": "1bac61830d3bc9c8234592861c735f58",
     "packages": [
         {
             "name": "psr/http-factory",

--- a/test/MessageTraitTest.php
+++ b/test/MessageTraitTest.php
@@ -24,7 +24,7 @@ class MessageTraitTest extends TestCase
      */
     protected $message;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->message = new Request(null, null, $this->createMock(StreamInterface::class));
     }

--- a/test/PhpInputStreamTest.php
+++ b/test/PhpInputStreamTest.php
@@ -27,7 +27,7 @@ class PhpInputStreamTest extends TestCase
      */
     protected $stream;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->file = __DIR__ . '/TestAsset/php-input-stream.txt';
         $this->stream = new PhpInputStream($this->file);

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -23,7 +23,7 @@ class RequestTest extends TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->request = new Request();
     }

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -42,7 +42,7 @@ class ResponseTest extends TestCase
     */
     protected $response;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->response = new Response();
     }
@@ -223,7 +223,7 @@ class ResponseTest extends TestCase
         $result = $response->getStatusCode();
 
         $this->assertSame((int) $code, $result);
-        $this->assertInternalType('int', $result);
+        $this->assertIsInt($result);
     }
 
     public function validStatusCodes()
@@ -311,7 +311,7 @@ class ResponseTest extends TestCase
     public function testReasonPhraseCanBeEmpty()
     {
         $response = $this->response->withStatus(555);
-        $this->assertInternalType('string', $response->getReasonPhrase());
+        $this->assertIsString($response->getReasonPhrase());
         $this->assertEmpty($response->getReasonPhrase());
     }
 

--- a/test/ServerRequestTest.php
+++ b/test/ServerRequestTest.php
@@ -23,7 +23,7 @@ class ServerRequestTest extends TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->request = new ServerRequest();
     }
@@ -182,7 +182,7 @@ class ServerRequestTest extends TestCase
     public function testCookieParamsAreAnEmptyArrayAtInitialization()
     {
         $request = new ServerRequest();
-        $this->assertInternalType('array', $request->getCookieParams());
+        $this->assertIsArray($request->getCookieParams());
         $this->assertCount(0, $request->getCookieParams());
     }
 
@@ -192,7 +192,7 @@ class ServerRequestTest extends TestCase
     public function testQueryParamsAreAnEmptyArrayAtInitialization()
     {
         $request = new ServerRequest();
-        $this->assertInternalType('array', $request->getQueryParams());
+        $this->assertIsArray($request->getQueryParams());
         $this->assertCount(0, $request->getQueryParams());
     }
 

--- a/test/StreamTest.php
+++ b/test/StreamTest.php
@@ -46,13 +46,13 @@ class StreamTest extends TestCase
      */
     protected $stream;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tmpnam = null;
         $this->stream = new Stream('php://memory', 'wb+');
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if ($this->tmpnam && file_exists($this->tmpnam)) {
             unlink($this->tmpnam);

--- a/test/UploadedFileTest.php
+++ b/test/UploadedFileTest.php
@@ -39,12 +39,12 @@ class UploadedFileTest extends TestCase
 {
     protected $tmpFile;
 
-    public function setUp()
+    protected function setUp() : void
     {
         $this->tmpfile = null;
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if (is_string($this->tmpFile) && file_exists($this->tmpFile)) {
             unlink($this->tmpFile);


### PR DESCRIPTION
We cannot use yet PHPUnit 8 as `php-http/psr7-integration-tests` is not compatible with PHPUnit 8.

- [x] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->
